### PR TITLE
[FEAT] Solution 서비스 및 DTO 구현

### DIFF
--- a/src/main/java/org/sani/algolog/domain/solution/dto/SolutionRequest.java
+++ b/src/main/java/org/sani/algolog/domain/solution/dto/SolutionRequest.java
@@ -1,0 +1,39 @@
+package org.sani.algolog.domain.solution.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.solution.entity.Solution;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SolutionRequest {
+
+    @NotBlank
+    private String code;
+
+    @NotNull
+    @Min(0)
+    private Integer timeElapsed;
+
+    @NotNull
+    private Boolean solved;
+
+    @NotNull
+    private Long problemId;
+
+    public Solution toEntity(Member member){
+        return Solution.builder()
+                .code(this.getCode())
+                .timeElapsed(this.getTimeElapsed())
+                .isSolved(this.getSolved())
+                .problemId(this.getProblemId())
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/solution/dto/SolutionResponse.java
+++ b/src/main/java/org/sani/algolog/domain/solution/dto/SolutionResponse.java
@@ -1,0 +1,34 @@
+package org.sani.algolog.domain.solution.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.sani.algolog.domain.solution.entity.Solution;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SolutionResponse {
+
+    private Long id;
+    private String code;
+    private Integer timeElapsed;
+    private boolean solved;
+    private Long problemId;
+    private Long memberId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static SolutionResponse from(Solution solution) {
+        return SolutionResponse.builder()
+                .id(solution.getId())
+                .code(solution.getCode())
+                .timeElapsed(solution.getTimeElapsed())
+                .solved(solution.isSolved())
+                .problemId(solution.getProblemId())
+                .memberId(solution.getMember().getId())
+                .createdAt(solution.getCreatedAt())
+                .updatedAt(solution.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
+++ b/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
@@ -40,4 +40,11 @@ public class Solution extends BaseEntity {
         this.problemId = problemId;
         this.member = member;
     }
+
+    public void update(String code, Integer timeElapsed, boolean isSolved, Long problemId) {
+        this.code = code;
+        this.timeElapsed = timeElapsed;
+        this.isSolved = isSolved;
+        this.problemId = problemId;
+    }
 }

--- a/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
+++ b/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
@@ -1,0 +1,77 @@
+package org.sani.algolog.domain.solution.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.domain.solution.dto.SolutionRequest;
+import org.sani.algolog.domain.solution.dto.SolutionResponse;
+import org.sani.algolog.domain.solution.entity.Solution;
+import org.sani.algolog.domain.solution.repository.SolutionRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SolutionService {
+
+    private final SolutionRepository solutionRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public SolutionResponse save(SolutionRequest request, Long memberId) {
+        Member member = findMember(memberId);
+        Solution solution = request.toEntity(member);
+
+        Solution savedSolution = solutionRepository.save(solution);
+        return SolutionResponse.from(savedSolution);
+    }
+
+    @Transactional
+    public SolutionResponse update(Long solutionId, SolutionRequest request, Long memberId) {
+        Solution solution = findSolution(solutionId);
+        validateOwner(solution, memberId);
+
+        solution.update(
+                request.getCode(),
+                request.getTimeElapsed(),
+                request.getSolved(),
+                request.getProblemId()
+        );
+
+        return SolutionResponse.from(solution);
+    }
+
+    @Transactional
+    public void delete(Long solutionId, Long memberId) {
+        Solution solution = findSolution(solutionId);
+        validateOwner(solution, memberId);
+        solutionRepository.delete(solution);
+    }
+
+    public List<SolutionResponse> getSolutionsByMember(Long memberId) {
+        return solutionRepository.findAllByMemberId(memberId).stream()
+                .map(SolutionResponse::from)
+                .toList();
+    }
+
+    private Solution findSolution(Long solutionId) {
+        return solutionRepository.findById(solutionId)
+                .orElseThrow(() -> new EntityNotFoundException("Solution not found: " + solutionId));
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found: " + memberId));
+    }
+
+    private void validateOwner(Solution solution, Long memberId) {
+        if (!solution.getMember().getId().equals(memberId)) {
+            throw new AccessDeniedException("작성자만 수정/삭제할 수 있습니다.");
+        }
+    }
+}

--- a/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
@@ -1,0 +1,202 @@
+package org.sani.algolog.domain.solution.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.domain.solution.dto.SolutionRequest;
+import org.sani.algolog.domain.solution.dto.SolutionResponse;
+import org.sani.algolog.domain.solution.entity.Solution;
+import org.sani.algolog.domain.solution.repository.SolutionRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SolutionServiceTest {
+
+    @Mock
+    private SolutionRepository solutionRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private SolutionService solutionService;
+
+    @Test
+    @DisplayName("풀이 등록 성공")
+    void saveSolution() {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(1L);
+
+        SolutionRequest request = new SolutionRequest("code", 120, true, 10L);
+
+        Solution savedSolution = Solution.builder()
+                .code("code")
+                .timeElapsed(120)
+                .isSolved(true)
+                .problemId(10L)
+                .member(member)
+                .build();
+        ReflectionTestUtils.setField(savedSolution, "id", 100L);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(solutionRepository.save(any(Solution.class))).thenReturn(savedSolution);
+
+        SolutionResponse response = solutionService.save(request, 1L);
+
+        ArgumentCaptor<Solution> captor = ArgumentCaptor.forClass(Solution.class);
+        verify(solutionRepository).save(captor.capture());
+        Solution captured = captor.getValue();
+        assertThat(captured.getCode()).isEqualTo(request.getCode());
+        assertThat(captured.getTimeElapsed()).isEqualTo(request.getTimeElapsed());
+        assertThat(captured.isSolved()).isEqualTo(request.getSolved());
+        assertThat(captured.getProblemId()).isEqualTo(request.getProblemId());
+        assertThat(captured.getMember()).isEqualTo(member);
+
+        assertThat(response.getId()).isEqualTo(100L);
+        assertThat(response.getProblemId()).isEqualTo(10L);
+        assertThat(response.isSolved()).isTrue();
+        assertThat(response.getMemberId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("풀이 수정 성공")
+    void updateSolution() {
+        Member owner = mock(Member.class);
+        when(owner.getId()).thenReturn(1L);
+
+        Solution solution = Solution.builder()
+                .code("old")
+                .timeElapsed(30)
+                .isSolved(false)
+                .problemId(5L)
+                .member(owner)
+                .build();
+        ReflectionTestUtils.setField(solution, "id", 1L);
+
+        when(solutionRepository.findById(1L)).thenReturn(Optional.of(solution));
+
+        SolutionRequest request = new SolutionRequest("new", 60, true, 7L);
+        SolutionResponse response = solutionService.update(1L, request, 1L);
+
+        assertThat(solution.getCode()).isEqualTo("new");
+        assertThat(solution.getTimeElapsed()).isEqualTo(60);
+        assertThat(solution.isSolved()).isTrue();
+        assertThat(solution.getProblemId()).isEqualTo(7L);
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getProblemId()).isEqualTo(7L);
+    }
+
+    @Test
+    @DisplayName("작성자가 아닌 경우 수정 실패")
+    void updateSolutionAccessDenied() {
+        Member owner = mock(Member.class);
+        when(owner.getId()).thenReturn(1L);
+
+        Solution solution = Solution.builder()
+                .code("old")
+                .timeElapsed(30)
+                .isSolved(false)
+                .problemId(5L)
+                .member(owner)
+                .build();
+
+        when(solutionRepository.findById(1L)).thenReturn(Optional.of(solution));
+
+        SolutionRequest request = new SolutionRequest("new", 60, true, 7L);
+
+        assertThatThrownBy(() -> solutionService.update(1L, request, 2L))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("풀이 삭제 성공")
+    void deleteSolution() {
+        Member owner = mock(Member.class);
+        when(owner.getId()).thenReturn(1L);
+
+        Solution solution = Solution.builder()
+                .code("code")
+                .timeElapsed(30)
+                .isSolved(true)
+                .problemId(5L)
+                .member(owner)
+                .build();
+
+        when(solutionRepository.findById(1L)).thenReturn(Optional.of(solution));
+
+        solutionService.delete(1L, 1L);
+
+        verify(solutionRepository).delete(solution);
+    }
+
+    @Test
+    @DisplayName("작성자가 아닌 경우 삭제 실패")
+    void deleteSolutionAccessDenied() {
+        Member owner = mock(Member.class);
+        when(owner.getId()).thenReturn(1L);
+
+        Solution solution = Solution.builder()
+                .code("code")
+                .timeElapsed(30)
+                .isSolved(true)
+                .problemId(5L)
+                .member(owner)
+                .build();
+
+        when(solutionRepository.findById(1L)).thenReturn(Optional.of(solution));
+
+        assertThatThrownBy(() -> solutionService.delete(1L, 2L))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("회원 ID로 풀이 목록 조회 성공")
+    void getSolutionsByMember() {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(3L);
+
+        Solution solution = Solution.builder()
+                .code("code")
+                .timeElapsed(10)
+                .isSolved(true)
+                .problemId(2L)
+                .member(member)
+                .build();
+        ReflectionTestUtils.setField(solution, "id", 99L);
+
+        when(solutionRepository.findAllByMemberId(3L)).thenReturn(List.of(solution));
+
+        List<SolutionResponse> responses = solutionService.getSolutionsByMember(3L);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getId()).isEqualTo(99L);
+        assertThat(responses.get(0).getMemberId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("풀이 ID가 없으면 예외")
+    void findSolutionNotFound() {
+        when(solutionRepository.findById(1L)).thenReturn(Optional.empty());
+
+        SolutionRequest request = new SolutionRequest("code", 10, true, 2L);
+
+        assertThatThrownBy(() -> solutionService.update(1L, request, 1L))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## 🎫 관련 이슈 (Issue)
Closes #6

## 🛠️ 작업 내용 (Changes)
- [x] Solution 요청/응답 DTO 구현 및 변환 로직 추가
- [x] Solution 서비스 레이어 구현 (저장/수정/삭제/조회)
- [x] Solution 서비스 단위 테스트(Mockito) 추가

## 📸 스크린샷 (Optional)

## 🤖 자가 점검 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 💬 리뷰 포인트 (Review Point)
- DTO에 `toEntity`를 두는 구조에 대한 의견을 부탁드립니다.
- 서비스가 `memberId` 기반으로 동작하도록 변경했는데 구조적으로 괜찮은지 확인 부탁드립니다.