### PR TITLE
[CHORE] 공통 예외 처리 구조 도입

### DIFF
--- a/src/main/java/org/sani/algolog/global/common/ApiResponse.java
+++ b/src/main/java/org/sani/algolog/global/common/ApiResponse.java
@@ -37,4 +37,12 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> fail(ErrorCode errorCode, String message) {
         return new ApiResponse<>(errorCode.getStatus(), errorCode.getCode(), message, null);
     }
+
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode, T data) {
+        return new ApiResponse<>(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage(), data);
+    }
+
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode, String message, T data) {
+        return new ApiResponse<>(errorCode.getStatus(), errorCode.getCode(), message, data);
+    }
 }

--- a/src/main/java/org/sani/algolog/global/error/ErrorCode.java
+++ b/src/main/java/org/sani/algolog/global/error/ErrorCode.java
@@ -7,9 +7,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
     BAD_REQUEST(400, "BAD_REQUEST", "요청이 올바르지 않습니다."),
+    INVALID_INPUT(400, "INVALID_INPUT", "입력값 검증에 실패했습니다."),
+    TYPE_MISMATCH(400, "TYPE_MISMATCH", "요청 파라미터 타입이 올바르지 않습니다."),
+    MISSING_PARAMETER(400, "MISSING_PARAMETER", "필수 요청 파라미터가 누락되었습니다."),
+    MESSAGE_NOT_READABLE(400, "MESSAGE_NOT_READABLE", "요청 본문을 읽을 수 없습니다."),
     UNAUTHORIZED(401, "UNAUTHORIZED", "인증이 필요합니다."),
     FORBIDDEN(403, "FORBIDDEN", "접근 권한이 없습니다."),
     NOT_FOUND(404, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(405, "METHOD_NOT_ALLOWED", "지원하지 않는 HTTP 메서드입니다."),
     CONFLICT(409, "CONFLICT", "요청이 현재 상태와 충돌합니다."),
     INTERNAL_SERVER_ERROR(500, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/org/sani/algolog/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/sani/algolog/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,124 @@
+package org.sani.algolog.global.error;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.sani.algolog.global.common.ApiResponse;
+import org.sani.algolog.global.error.dto.FieldErrorDetail;
+import org.sani.algolog.global.error.exception.AlgoLogException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AlgoLogException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAlgoLogException(AlgoLogException exception) {
+        return errorResponse(exception.getErrorCode(), exception.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<List<FieldErrorDetail>>> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception
+    ) {
+        List<FieldErrorDetail> fieldErrors = extractFieldErrors(exception.getBindingResult());
+        return errorResponse(ErrorCode.INVALID_INPUT, ErrorCode.INVALID_INPUT.getMessage(), fieldErrors);
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<List<FieldErrorDetail>>> handleBindException(BindException exception) {
+        List<FieldErrorDetail> fieldErrors = extractFieldErrors(exception.getBindingResult());
+        return errorResponse(ErrorCode.INVALID_INPUT, ErrorCode.INVALID_INPUT.getMessage(), fieldErrors);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<List<FieldErrorDetail>>> handleConstraintViolationException(
+            ConstraintViolationException exception
+    ) {
+        List<FieldErrorDetail> fieldErrors = exception.getConstraintViolations().stream()
+                .map(violation -> new FieldErrorDetail(
+                        violation.getPropertyPath().toString(),
+                        violation.getMessage(),
+                        violation.getInvalidValue()))
+                .toList();
+
+        return errorResponse(ErrorCode.INVALID_INPUT, ErrorCode.INVALID_INPUT.getMessage(), fieldErrors);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException exception
+    ) {
+        String requiredType = exception.getRequiredType() == null
+                ? "unknown"
+                : exception.getRequiredType().getSimpleName();
+
+        String message = "파라미터 '" + exception.getName() + "'의 타입은 " + requiredType + " 이어야 합니다.";
+        return errorResponse(ErrorCode.TYPE_MISMATCH, message);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException exception
+    ) {
+        String message = "필수 파라미터 '" + exception.getParameterName() + "'가 누락되었습니다.";
+        return errorResponse(ErrorCode.MISSING_PARAMETER, message);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException exception
+    ) {
+        String message = "'" + exception.getMethod() + "' 메서드는 이 엔드포인트에서 지원하지 않습니다.";
+        return errorResponse(ErrorCode.METHOD_NOT_ALLOWED, message);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException exception
+    ) {
+        return errorResponse(ErrorCode.MESSAGE_NOT_READABLE, ErrorCode.MESSAGE_NOT_READABLE.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception exception) {
+        log.error("Unhandled exception occurred", exception);
+        return errorResponse(ErrorCode.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+    }
+
+    private List<FieldErrorDetail> extractFieldErrors(BindingResult bindingResult) {
+        return bindingResult.getFieldErrors().stream()
+                .map(this::toFieldErrorDetail)
+                .toList();
+    }
+
+    private FieldErrorDetail toFieldErrorDetail(org.springframework.validation.FieldError fieldError) {
+        String reason = fieldError.getDefaultMessage() == null || fieldError.getDefaultMessage().isBlank()
+                ? "잘못된 값입니다."
+                : fieldError.getDefaultMessage();
+
+        return new FieldErrorDetail(fieldError.getField(), reason, fieldError.getRejectedValue());
+    }
+
+    private ResponseEntity<ApiResponse<Void>> errorResponse(ErrorCode errorCode, String message) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode, message));
+    }
+
+    private <T> ResponseEntity<ApiResponse<T>> errorResponse(ErrorCode errorCode, String message, T data) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode, message, data));
+    }
+}

--- a/src/main/java/org/sani/algolog/global/error/dto/FieldErrorDetail.java
+++ b/src/main/java/org/sani/algolog/global/error/dto/FieldErrorDetail.java
@@ -1,0 +1,8 @@
+package org.sani.algolog.global.error.dto;
+
+public record FieldErrorDetail(
+        String field,
+        String reason,
+        Object rejectedValue
+) {
+}

--- a/src/main/java/org/sani/algolog/global/error/exception/AlgoLogException.java
+++ b/src/main/java/org/sani/algolog/global/error/exception/AlgoLogException.java
@@ -1,0 +1,20 @@
+package org.sani.algolog.global.error.exception;
+
+import lombok.Getter;
+import org.sani.algolog.global.error.ErrorCode;
+
+@Getter
+public class AlgoLogException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AlgoLogException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public AlgoLogException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/sani/algolog/global/error/exception/BadRequestException.java
+++ b/src/main/java/org/sani/algolog/global/error/exception/BadRequestException.java
@@ -1,0 +1,14 @@
+package org.sani.algolog.global.error.exception;
+
+import org.sani.algolog.global.error.ErrorCode;
+
+public class BadRequestException extends AlgoLogException {
+
+    public BadRequestException() {
+        super(ErrorCode.BAD_REQUEST);
+    }
+
+    public BadRequestException(String message) {
+        super(ErrorCode.BAD_REQUEST, message);
+    }
+}

--- a/src/main/java/org/sani/algolog/global/error/exception/ConflictException.java
+++ b/src/main/java/org/sani/algolog/global/error/exception/ConflictException.java
@@ -1,0 +1,14 @@
+package org.sani.algolog.global.error.exception;
+
+import org.sani.algolog.global.error.ErrorCode;
+
+public class ConflictException extends AlgoLogException {
+
+    public ConflictException() {
+        super(ErrorCode.CONFLICT);
+    }
+
+    public ConflictException(String message) {
+        super(ErrorCode.CONFLICT, message);
+    }
+}

--- a/src/main/java/org/sani/algolog/global/error/exception/ForbiddenException.java
+++ b/src/main/java/org/sani/algolog/global/error/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package org.sani.algolog.global.error.exception;
+
+import org.sani.algolog.global.error.ErrorCode;
+
+public class ForbiddenException extends AlgoLogException {
+
+    public ForbiddenException() {
+        super(ErrorCode.FORBIDDEN);
+    }
+
+    public ForbiddenException(String message) {
+        super(ErrorCode.FORBIDDEN, message);
+    }
+}

--- a/src/main/java/org/sani/algolog/global/error/exception/NotFoundException.java
+++ b/src/main/java/org/sani/algolog/global/error/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package org.sani.algolog.global.error.exception;
+
+import org.sani.algolog.global.error.ErrorCode;
+
+public class NotFoundException extends AlgoLogException {
+
+    public NotFoundException() {
+        super(ErrorCode.NOT_FOUND);
+    }
+
+    public NotFoundException(String message) {
+        super(ErrorCode.NOT_FOUND, message);
+    }
+}

--- a/src/main/java/org/sani/algolog/global/error/exception/UnauthorizedException.java
+++ b/src/main/java/org/sani/algolog/global/error/exception/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package org.sani.algolog.global.error.exception;
+
+import org.sani.algolog.global.error.ErrorCode;
+
+public class UnauthorizedException extends AlgoLogException {
+
+    public UnauthorizedException() {
+        super(ErrorCode.UNAUTHORIZED);
+    }
+
+    public UnauthorizedException(String message) {
+        super(ErrorCode.UNAUTHORIZED, message);
+    }
+}

--- a/src/test/java/org/sani/algolog/global/common/ApiResponseTest.java
+++ b/src/test/java/org/sani/algolog/global/common/ApiResponseTest.java
@@ -1,0 +1,39 @@
+package org.sani.algolog.global.common;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sani.algolog.global.error.ErrorCode;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiResponseTest {
+
+    @Test
+    @DisplayName("fail(ErrorCode, data) returns data with default error message")
+    void failWithData() {
+        List<String> details = List.of("title is required");
+
+        ApiResponse<List<String>> response = ApiResponse.fail(ErrorCode.INVALID_INPUT, details);
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.INVALID_INPUT.getStatus());
+        assertThat(response.getCode()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+        assertThat(response.getMessage()).isEqualTo(ErrorCode.INVALID_INPUT.getMessage());
+        assertThat(response.getData()).containsExactly("title is required");
+    }
+
+    @Test
+    @DisplayName("fail(ErrorCode, message, data) returns custom message and data")
+    void failWithCustomMessageAndData() {
+        List<String> details = List.of("field:title");
+        String customMessage = "Validation failed for request.";
+
+        ApiResponse<List<String>> response = ApiResponse.fail(ErrorCode.INVALID_INPUT, customMessage, details);
+
+        assertThat(response.getStatus()).isEqualTo(ErrorCode.INVALID_INPUT.getStatus());
+        assertThat(response.getCode()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+        assertThat(response.getMessage()).isEqualTo(customMessage);
+        assertThat(response.getData()).containsExactly("field:title");
+    }
+}

--- a/src/test/java/org/sani/algolog/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/org/sani/algolog/global/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,97 @@
+package org.sani.algolog.global.error;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = TestExceptionController.class)
+@Import(GlobalExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("custom exception is converted to ApiResponse")
+    void handleCustomException() throws Exception {
+        mockMvc.perform(get("/test/custom"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("Target resource does not exist."))
+                .andExpect(jsonPath("$.data").value(Matchers.nullValue()));
+    }
+
+    @Test
+    @DisplayName("validation error returns INVALID_INPUT with field details")
+    void handleValidationException() throws Exception {
+        mockMvc.perform(post("/test/valid")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.data[0].field").value("title"))
+                .andExpect(jsonPath("$.data[0].reason").value("title is required"));
+    }
+
+    @Test
+    @DisplayName("type mismatch returns TYPE_MISMATCH")
+    void handleTypeMismatchException() throws Exception {
+        mockMvc.perform(get("/test/type").param("count", "abc"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("TYPE_MISMATCH"));
+    }
+
+    @Test
+    @DisplayName("missing parameter returns MISSING_PARAMETER")
+    void handleMissingParameterException() throws Exception {
+        mockMvc.perform(get("/test/required"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("MISSING_PARAMETER"));
+    }
+
+    @Test
+    @DisplayName("method not allowed returns METHOD_NOT_ALLOWED")
+    void handleMethodNotAllowedException() throws Exception {
+        mockMvc.perform(post("/test/type"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.code").value("METHOD_NOT_ALLOWED"));
+    }
+
+    @Test
+    @DisplayName("malformed body returns MESSAGE_NOT_READABLE")
+    void handleMessageNotReadableException() throws Exception {
+        mockMvc.perform(post("/test/valid")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("MESSAGE_NOT_READABLE"));
+    }
+
+    @Test
+    @DisplayName("unexpected exception returns INTERNAL_SERVER_ERROR")
+    void handleUnknownException() throws Exception {
+        mockMvc.perform(get("/test/unexpected"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"));
+    }
+
+}

--- a/src/test/java/org/sani/algolog/global/error/TestExceptionController.java
+++ b/src/test/java/org/sani/algolog/global/error/TestExceptionController.java
@@ -1,0 +1,49 @@
+package org.sani.algolog.global.error;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.sani.algolog.global.error.exception.NotFoundException;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/test")
+public class TestExceptionController {
+
+    @GetMapping("/custom")
+    public String custom() {
+        throw new NotFoundException("Target resource does not exist.");
+    }
+
+    @PostMapping("/valid")
+    public String valid(@Valid @RequestBody TestRequest request) {
+        return "ok";
+    }
+
+    @GetMapping("/type")
+    public String type(@RequestParam int count) {
+        return "count=" + count;
+    }
+
+    @GetMapping("/required")
+    public String required(@RequestParam String keyword) {
+        return keyword;
+    }
+
+    @GetMapping("/unexpected")
+    public String unexpected() {
+        throw new IllegalStateException("boom");
+    }
+
+    public record TestRequest(
+            @NotBlank(message = "title is required")
+            String title
+    ) {
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Issue)
Closes #10

## 📌 작업 내용 (Changes)
- [x] ErrorCode 확장 및 공통 커스텀 예외 계층 추가
- [x] 전역 예외 핸들러 구현 및 주요 내장 예외 매핑 적용
- [x] ApiResponse 확장 및 예외 처리 테스트 코드 추가

## 📷 스크린샷 (Optional)
- 없음

## ✅ 체크리스트 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그 및 주석은 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 🙋 리뷰 포인트(Review Point)
- GlobalExceptionHandler의 예외 매핑 범위와 메시지 정책이 팀 기준에 맞는지
- validation 실패 응답(`data: List<FieldErrorDetail>`) 형식이 클라이언트 기대 포맷과 맞는지