### PR TITLE
[CHORE] Swagger 설정 및 Solution API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
+++ b/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
@@ -1,0 +1,56 @@
+package org.sani.algolog.domain.solution.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.domain.solution.dto.SolutionRequest;
+import org.sani.algolog.domain.solution.dto.SolutionResponse;
+import org.sani.algolog.domain.solution.service.SolutionService;
+import org.sani.algolog.global.common.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Solution", description = "Solution APIs")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/solutions")
+public class SolutionController {
+
+    private static final String MEMBER_ID_HEADER = "X-Member-Id";
+
+    private final SolutionService solutionService;
+
+    @Operation(summary = "Save solution", description = "Saves a solution for the member in X-Member-Id header.")
+    @PostMapping
+    public ApiResponse<SolutionResponse> save(
+            @RequestHeader(MEMBER_ID_HEADER) Long memberId,
+            @Valid @RequestBody SolutionRequest request
+    ) {
+        return ApiResponse.success(solutionService.save(request, memberId));
+    }
+
+    @Operation(summary = "Get my solutions", description = "Returns all solutions owned by the member in latest-first order.")
+    @GetMapping
+    public ApiResponse<List<SolutionResponse>> getSolutions(
+            @RequestHeader(MEMBER_ID_HEADER) Long memberId
+    ) {
+        return ApiResponse.success(solutionService.getSolutionsByMember(memberId));
+    }
+
+    @Operation(summary = "Get solution detail", description = "Returns a single solution only when owned by the member.")
+    @GetMapping("/{id}")
+    public ApiResponse<SolutionResponse> getSolution(
+            @PathVariable Long id,
+            @RequestHeader(MEMBER_ID_HEADER) Long memberId
+    ) {
+        return ApiResponse.success(solutionService.getSolution(id, memberId));
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/solution/repository/SolutionRepository.java
+++ b/src/main/java/org/sani/algolog/domain/solution/repository/SolutionRepository.java
@@ -4,7 +4,12 @@ import org.sani.algolog.domain.solution.entity.Solution;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SolutionRepository extends JpaRepository<Solution, Long> {
     List<Solution> findAllByMemberId(Long memberId);
+
+    List<Solution> findAllByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    Optional<Solution> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
+++ b/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
@@ -54,9 +54,16 @@ public class SolutionService {
     }
 
     public List<SolutionResponse> getSolutionsByMember(Long memberId) {
-        return solutionRepository.findAllByMemberId(memberId).stream()
+        findMember(memberId);
+        return solutionRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId).stream()
                 .map(SolutionResponse::from)
                 .toList();
+    }
+
+    public SolutionResponse getSolution(Long solutionId, Long memberId) {
+        Solution solution = findSolution(solutionId);
+        validateOwner(solution, memberId);
+        return SolutionResponse.from(solution);
     }
 
     private Solution findSolution(Long solutionId) {

--- a/src/main/java/org/sani/algolog/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sani/algolog/global/config/SwaggerConfig.java
@@ -1,0 +1,33 @@
+package org.sani.algolog.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String MEMBER_ID_SCHEME = "memberIdHeader";
+    private static final String MEMBER_ID_HEADER = "X-Member-Id";
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme memberIdScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name(MEMBER_ID_HEADER)
+                .description("Temporary member identification header for MVP APIs.");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("AlgoLog API")
+                        .version("v1")
+                        .description("AlgoLog REST API documentation"))
+                .components(new Components().addSecuritySchemes(MEMBER_ID_SCHEME, memberIdScheme))
+                .addSecurityItem(new SecurityRequirement().addList(MEMBER_ID_SCHEME));
+    }
+}

--- a/src/main/java/org/sani/algolog/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/sani/algolog/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.sani.algolog.global.error;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.sani.algolog.global.common.ApiResponse;
@@ -7,11 +8,13 @@ import org.sani.algolog.global.error.dto.FieldErrorDetail;
 import org.sani.algolog.global.error.exception.AlgoLogException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -25,6 +28,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AlgoLogException.class)
     public ResponseEntity<ApiResponse<Void>> handleAlgoLogException(AlgoLogException exception) {
         return errorResponse(exception.getErrorCode(), exception.getMessage());
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleEntityNotFoundException(EntityNotFoundException exception) {
+        return errorResponse(ErrorCode.NOT_FOUND, messageOrDefault(exception.getMessage(), ErrorCode.NOT_FOUND));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException exception) {
+        return errorResponse(ErrorCode.FORBIDDEN, messageOrDefault(exception.getMessage(), ErrorCode.FORBIDDEN));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -63,7 +76,7 @@ public class GlobalExceptionHandler {
                 ? "unknown"
                 : exception.getRequiredType().getSimpleName();
 
-        String message = "파라미터 '" + exception.getName() + "'의 타입은 " + requiredType + " 이어야 합니다.";
+        String message = "Parameter '" + exception.getName() + "' must be of type " + requiredType + ".";
         return errorResponse(ErrorCode.TYPE_MISMATCH, message);
     }
 
@@ -71,15 +84,22 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameterException(
             MissingServletRequestParameterException exception
     ) {
-        String message = "필수 파라미터 '" + exception.getParameterName() + "'가 누락되었습니다.";
+        String message = "Required parameter '" + exception.getParameterName() + "' is missing.";
         return errorResponse(ErrorCode.MISSING_PARAMETER, message);
+    }
+
+    @ExceptionHandler(ServletRequestBindingException.class)
+    public ResponseEntity<ApiResponse<Void>> handleServletRequestBindingException(
+            ServletRequestBindingException exception
+    ) {
+        return errorResponse(ErrorCode.MISSING_PARAMETER, exception.getMessage());
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupportedException(
             HttpRequestMethodNotSupportedException exception
     ) {
-        String message = "'" + exception.getMethod() + "' 메서드는 이 엔드포인트에서 지원하지 않습니다.";
+        String message = "HTTP method '" + exception.getMethod() + "' is not supported for this endpoint.";
         return errorResponse(ErrorCode.METHOD_NOT_ALLOWED, message);
     }
 
@@ -104,10 +124,14 @@ public class GlobalExceptionHandler {
 
     private FieldErrorDetail toFieldErrorDetail(org.springframework.validation.FieldError fieldError) {
         String reason = fieldError.getDefaultMessage() == null || fieldError.getDefaultMessage().isBlank()
-                ? "잘못된 값입니다."
+                ? "Invalid value."
                 : fieldError.getDefaultMessage();
 
         return new FieldErrorDetail(fieldError.getField(), reason, fieldError.getRejectedValue());
+    }
+
+    private String messageOrDefault(String message, ErrorCode errorCode) {
+        return message == null || message.isBlank() ? errorCode.getMessage() : message;
     }
 
     private ResponseEntity<ApiResponse<Void>> errorResponse(ErrorCode errorCode, String message) {

--- a/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
@@ -1,0 +1,168 @@
+package org.sani.algolog.domain.solution.controller;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sani.algolog.domain.solution.dto.SolutionResponse;
+import org.sani.algolog.domain.solution.service.SolutionService;
+import org.sani.algolog.global.error.GlobalExceptionHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SolutionController.class)
+@Import(GlobalExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SolutionControllerTest {
+
+    private static final String BASE_URL = "/api/v1/solutions";
+    private static final String MEMBER_ID_HEADER = "X-Member-Id";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SolutionService solutionService;
+
+    @Test
+    @DisplayName("POST /api/v1/solutions returns SUCCESS")
+    void saveSolution() throws Exception {
+        SolutionResponse response = solutionResponse(100L, 1L, 10L);
+        when(solutionService.save(any(), eq(1L))).thenReturn(response);
+
+        String body = """
+                {
+                  "code": "public class Main {}",
+                  "timeElapsed": 123,
+                  "solved": true,
+                  "problemId": 10
+                }
+                """;
+
+        mockMvc.perform(post(BASE_URL)
+                        .header(MEMBER_ID_HEADER, "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.id").value(100))
+                .andExpect(jsonPath("$.data.memberId").value(1))
+                .andExpect(jsonPath("$.data.problemId").value(10));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/solutions validation failure returns INVALID_INPUT")
+    void saveSolutionValidationFailure() throws Exception {
+        String invalidBody = """
+                {
+                  "code": "",
+                  "timeElapsed": -1,
+                  "solved": null
+                }
+                """;
+
+        mockMvc.perform(post(BASE_URL)
+                        .header(MEMBER_ID_HEADER, "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/solutions returns list")
+    void getSolutions() throws Exception {
+        SolutionResponse first = solutionResponse(11L, 1L, 101L);
+        SolutionResponse second = solutionResponse(10L, 1L, 100L);
+        when(solutionService.getSolutionsByMember(1L)).thenReturn(List.of(first, second));
+
+        mockMvc.perform(get(BASE_URL)
+                        .header(MEMBER_ID_HEADER, "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].id").value(11))
+                .andExpect(jsonPath("$.data[1].id").value(10));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/solutions/{id} returns detail")
+    void getSolution() throws Exception {
+        when(solutionService.getSolution(100L, 1L)).thenReturn(solutionResponse(100L, 1L, 10L));
+
+        mockMvc.perform(get(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.id").value(100));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/solutions/{id} forbidden returns FORBIDDEN")
+    void getSolutionForbidden() throws Exception {
+        when(solutionService.getSolution(100L, 1L))
+                .thenThrow(new AccessDeniedException("Access is denied."));
+
+        mockMvc.perform(get(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/solutions/{id} missing returns NOT_FOUND")
+    void getSolutionNotFound() throws Exception {
+        when(solutionService.getSolution(100L, 1L))
+                .thenThrow(new EntityNotFoundException("Solution not found: 100"));
+
+        mockMvc.perform(get(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("missing X-Member-Id header returns MISSING_PARAMETER")
+    void missingMemberIdHeader() throws Exception {
+        mockMvc.perform(get(BASE_URL))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("MISSING_PARAMETER"));
+    }
+
+    private SolutionResponse solutionResponse(Long id, Long memberId, Long problemId) {
+        LocalDateTime now = LocalDateTime.now();
+        return SolutionResponse.builder()
+                .id(id)
+                .code("public class Main {}")
+                .timeElapsed(120)
+                .solved(true)
+                .problemId(problemId)
+                .memberId(memberId)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+    }
+}

--- a/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
@@ -193,6 +193,15 @@ class SolutionServiceTest {
     }
 
     @Test
+    @DisplayName("get member solutions raises not found when member does not exist")
+    void getSolutionsByMemberNotFound() {
+        when(memberRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> solutionService.getSolutionsByMember(99L))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
     @DisplayName("get solution detail succeeds for owner")
     void getSolutionById() {
         Member owner = mock(Member.class);

--- a/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
@@ -23,7 +23,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SolutionServiceTest {
@@ -38,7 +40,7 @@ class SolutionServiceTest {
     private SolutionService solutionService;
 
     @Test
-    @DisplayName("풀이 등록 성공")
+    @DisplayName("save solution succeeds")
     void saveSolution() {
         Member member = mock(Member.class);
         when(member.getId()).thenReturn(1L);
@@ -75,7 +77,7 @@ class SolutionServiceTest {
     }
 
     @Test
-    @DisplayName("풀이 수정 성공")
+    @DisplayName("update solution succeeds")
     void updateSolution() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
@@ -103,7 +105,7 @@ class SolutionServiceTest {
     }
 
     @Test
-    @DisplayName("작성자가 아닌 경우 수정 실패")
+    @DisplayName("update is denied for non-owner")
     void updateSolutionAccessDenied() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
@@ -125,7 +127,7 @@ class SolutionServiceTest {
     }
 
     @Test
-    @DisplayName("풀이 삭제 성공")
+    @DisplayName("delete solution succeeds")
     void deleteSolution() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
@@ -146,7 +148,7 @@ class SolutionServiceTest {
     }
 
     @Test
-    @DisplayName("작성자가 아닌 경우 삭제 실패")
+    @DisplayName("delete is denied for non-owner")
     void deleteSolutionAccessDenied() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
@@ -166,7 +168,7 @@ class SolutionServiceTest {
     }
 
     @Test
-    @DisplayName("회원 ID로 풀이 목록 조회 성공")
+    @DisplayName("get member solutions succeeds")
     void getSolutionsByMember() {
         Member member = mock(Member.class);
         when(member.getId()).thenReturn(3L);
@@ -180,7 +182,8 @@ class SolutionServiceTest {
                 .build();
         ReflectionTestUtils.setField(solution, "id", 99L);
 
-        when(solutionRepository.findAllByMemberId(3L)).thenReturn(List.of(solution));
+        when(memberRepository.findById(3L)).thenReturn(Optional.of(member));
+        when(solutionRepository.findAllByMemberIdOrderByCreatedAtDesc(3L)).thenReturn(List.of(solution));
 
         List<SolutionResponse> responses = solutionService.getSolutionsByMember(3L);
 
@@ -190,7 +193,51 @@ class SolutionServiceTest {
     }
 
     @Test
-    @DisplayName("풀이 ID가 없으면 예외")
+    @DisplayName("get solution detail succeeds for owner")
+    void getSolutionById() {
+        Member owner = mock(Member.class);
+        when(owner.getId()).thenReturn(1L);
+
+        Solution solution = Solution.builder()
+                .code("code")
+                .timeElapsed(10)
+                .isSolved(true)
+                .problemId(2L)
+                .member(owner)
+                .build();
+        ReflectionTestUtils.setField(solution, "id", 7L);
+
+        when(solutionRepository.findById(7L)).thenReturn(Optional.of(solution));
+
+        SolutionResponse response = solutionService.getSolution(7L, 1L);
+
+        assertThat(response.getId()).isEqualTo(7L);
+        assertThat(response.getMemberId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("get solution detail is denied for non-owner")
+    void getSolutionByIdAccessDenied() {
+        Member owner = mock(Member.class);
+        when(owner.getId()).thenReturn(1L);
+
+        Solution solution = Solution.builder()
+                .code("code")
+                .timeElapsed(10)
+                .isSolved(true)
+                .problemId(2L)
+                .member(owner)
+                .build();
+        ReflectionTestUtils.setField(solution, "id", 7L);
+
+        when(solutionRepository.findById(7L)).thenReturn(Optional.of(solution));
+
+        assertThatThrownBy(() -> solutionService.getSolution(7L, 99L))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("missing solution raises not found")
     void findSolutionNotFound() {
         when(solutionRepository.findById(1L)).thenReturn(Optional.empty());
 

--- a/src/test/java/org/sani/algolog/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/org/sani/algolog/global/error/GlobalExceptionHandlerTest.java
@@ -94,4 +94,22 @@ class GlobalExceptionHandlerTest {
                 .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"));
     }
 
+    @Test
+    @DisplayName("entity not found exception returns NOT_FOUND")
+    void handleEntityNotFoundException() throws Exception {
+        mockMvc.perform(get("/test/jpa-not-found"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("access denied exception returns FORBIDDEN")
+    void handleAccessDeniedException() throws Exception {
+        mockMvc.perform(get("/test/forbidden"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
 }

--- a/src/test/java/org/sani/algolog/global/error/TestExceptionController.java
+++ b/src/test/java/org/sani/algolog/global/error/TestExceptionController.java
@@ -1,8 +1,10 @@
 package org.sani.algolog.global.error;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.sani.algolog.global.error.exception.NotFoundException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,6 +41,16 @@ public class TestExceptionController {
     @GetMapping("/unexpected")
     public String unexpected() {
         throw new IllegalStateException("boom");
+    }
+
+    @GetMapping("/jpa-not-found")
+    public String jpaNotFound() {
+        throw new EntityNotFoundException("Entity does not exist.");
+    }
+
+    @GetMapping("/forbidden")
+    public String forbidden() {
+        throw new AccessDeniedException("Access is denied.");
     }
 
     public record TestRequest(


### PR DESCRIPTION
﻿## 🔗 관련 이슈 (Issue)
Closes #7

## ✅ 주요 작업 내용 (Changes)
- [x] SpringDoc 의존성 추가 및 OpenAPI/Swagger 설정 추가 (`SwaggerConfig`)
- [x] `SolutionController` 구현
- [x] `POST /api/v1/solutions`, `GET /api/v1/solutions`, `GET /api/v1/solutions/{id}` 엔드포인트 추가
- [x] `GlobalExceptionHandler` 예외 매핑 보강 (`EntityNotFoundException`, `AccessDeniedException`, `ServletRequestBindingException`)
- [x] `SolutionService`, `SolutionRepository` 조회 로직 보강 및 정렬 기준(최신순) 반영
- [x] 컨트롤러/서비스/예외처리 테스트 보강

## 📸 스크린샷 (Optional)
- 없음

## ✅ 셀프 체크리스트 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그와 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 🔎 리뷰 포인트 (Review Point)
- `X-Member-Id` 임시 헤더 기반 식별 방식이 현재 이슈 범위에서 적절한지 확인 부탁드립니다.
- `POST` 요청은 현 보안 정책(CSRF) 영향으로 수동 호출 시 401이 발생하며, Security 정책 조정은 후속 작업으로 분리했습니다.
