### PR TITLE
[FEAT] Problem 도메인 모델 및 리포지토리 구현

### DIFF
--- a/src/main/java/org/sani/algolog/domain/problem/entity/Platform.java
+++ b/src/main/java/org/sani/algolog/domain/problem/entity/Platform.java
@@ -1,0 +1,10 @@
+package org.sani.algolog.domain.problem.entity;
+
+public enum Platform {
+    BOJ,
+    PROGRAMMERS,
+    SWEA,
+    CODE_TREE,
+    REET,
+    ETC
+}

--- a/src/main/java/org/sani/algolog/domain/problem/entity/Problem.java
+++ b/src/main/java/org/sani/algolog/domain/problem/entity/Problem.java
@@ -1,0 +1,66 @@
+package org.sani.algolog.domain.problem.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sani.algolog.global.common.BaseEntity;
+
+@Entity
+@Table(
+        name = "problems",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_problem_platform_external_id",
+                        columnNames = {"platform", "external_problem_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Problem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private Platform platform;
+
+    @Column(name = "external_problem_id", nullable = false, length = 100)
+    private String externalProblemId;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(nullable = false, length = 500)
+    private String problemUrl;
+
+    @Column(nullable = false, length = 50)
+    private String difficulty;
+
+    @Builder
+    public Problem(
+            Platform platform,
+            String externalProblemId,
+            String title,
+            String problemUrl,
+            String difficulty
+    ) {
+        this.platform = platform;
+        this.externalProblemId = externalProblemId;
+        this.title = title;
+        this.problemUrl = problemUrl;
+        this.difficulty = difficulty;
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/org/sani/algolog/domain/problem/repository/ProblemRepository.java
@@ -1,0 +1,12 @@
+package org.sani.algolog.domain.problem.repository;
+
+import org.sani.algolog.domain.problem.entity.Platform;
+import org.sani.algolog.domain.problem.entity.Problem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
+
+    Optional<Problem> findByPlatformAndExternalProblemId(Platform platform, String externalProblemId);
+}

--- a/src/test/java/org/sani/algolog/domain/problem/repository/ProblemRepositoryTest.java
+++ b/src/test/java/org/sani/algolog/domain/problem/repository/ProblemRepositoryTest.java
@@ -1,0 +1,38 @@
+package org.sani.algolog.domain.problem.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sani.algolog.domain.problem.entity.Platform;
+import org.sani.algolog.domain.problem.entity.Problem;
+import org.sani.algolog.global.config.JpaConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class ProblemRepositoryTest {
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Test
+    @DisplayName("플랫폼과 외부 문제 ID로 문제 조회 성공")
+    void findByPlatformAndExternalProblemId() {
+        Problem savedProblem = problemRepository.save(Problem.builder()
+                .platform(Platform.BOJ)
+                .externalProblemId("1000")
+                .title("A+B")
+                .problemUrl("https://www.acmicpc.net/problem/1000")
+                .difficulty("Bronze V")
+                .build());
+
+        Problem problem = problemRepository.findByPlatformAndExternalProblemId(Platform.BOJ, "1000")
+                .orElseThrow(() -> new IllegalArgumentException("문제가 없습니다."));
+
+        assertThat(problem.getId()).isEqualTo(savedProblem.getId());
+        assertThat(problem.getTitle()).isEqualTo("A+B");
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Issue)
Closes #15

## ✅ 주요 작업 내용 (Changes)
- [x] `Problem` 엔티티 추가
- [x] `Platform`, `externalProblemId`, `title`, `problemUrl`, `difficulty` 메타데이터 모델링
- [x] `platform + externalProblemId` 유니크 제약 추가
- [x] `ProblemRepository` 및 문제 조회 메서드 추가
- [x] `ProblemRepositoryTest` 작성 및 H2 기반 저장/조회 검증

## 📸 스크린샷 (Optional)
- 없음

## ✅ 셀프 체크리스트 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그와 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 🔎 리뷰 포인트 (Review Point)
- `Platform` enum 위치를 `problem` 도메인에 두는 현재 구조가 이후 `Solution` 연관관계 전환 작업과 잘 맞는지 확인 부탁드립니다.
- `problems` 테이블의 유니크 키를 `platform + externalProblemId`로 고정한 정책이 요구사항에 부합하는지 확인 부탁드립니다.
