### PR TITLE
[REFACTOR] Solution 엔티티의 problemId를 Problem 연관관계로 전환

### DIFF
--- a/src/main/java/org/sani/algolog/domain/solution/dto/SolutionRequest.java
+++ b/src/main/java/org/sani/algolog/domain/solution/dto/SolutionRequest.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.problem.entity.Problem;
 import org.sani.algolog.domain.solution.entity.Solution;
 
 @Getter
@@ -27,12 +28,12 @@ public class SolutionRequest {
     @NotNull
     private Long problemId;
 
-    public Solution toEntity(Member member){
+    public Solution toEntity(Member member, Problem problem){
         return Solution.builder()
                 .code(this.getCode())
                 .timeElapsed(this.getTimeElapsed())
                 .isSolved(this.getSolved())
-                .problemId(this.getProblemId())
+                .problem(problem)
                 .member(member)
                 .build();
     }

--- a/src/main/java/org/sani/algolog/domain/solution/dto/SolutionResponse.java
+++ b/src/main/java/org/sani/algolog/domain/solution/dto/SolutionResponse.java
@@ -25,7 +25,7 @@ public class SolutionResponse {
                 .code(solution.getCode())
                 .timeElapsed(solution.getTimeElapsed())
                 .solved(solution.isSolved())
-                .problemId(solution.getProblemId())
+                .problemId(solution.getProblem().getId())
                 .memberId(solution.getMember().getId())
                 .createdAt(solution.getCreatedAt())
                 .updatedAt(solution.getUpdatedAt())

--- a/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
+++ b/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.problem.entity.Problem;
 import org.sani.algolog.global.common.BaseEntity;
 
 @Entity
@@ -24,27 +25,27 @@ public class Solution extends BaseEntity {
 
     private boolean isSolved;
 
-    // TODO: Problem 엔티티 작업 완료 후 연관관계 매핑으로 교체
-    @Column(name = "problem_id", nullable = false)
-    private Long problemId;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
     @Builder
-    public Solution(String code, Integer timeElapsed, boolean isSolved, Long problemId, Member member) {
+    public Solution(String code, Integer timeElapsed, boolean isSolved, Problem problem, Member member) {
         this.code = code;
         this.timeElapsed = timeElapsed;
         this.isSolved = isSolved;
-        this.problemId = problemId;
+        this.problem = problem;
         this.member = member;
     }
 
-    public void update(String code, Integer timeElapsed, boolean isSolved, Long problemId) {
+    public void update(String code, Integer timeElapsed, boolean isSolved, Problem problem) {
         this.code = code;
         this.timeElapsed = timeElapsed;
         this.isSolved = isSolved;
-        this.problemId = problemId;
+        this.problem = problem;
     }
 }

--- a/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
+++ b/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sani.algolog.domain.member.entity.Member;
 import org.sani.algolog.domain.problem.entity.Problem;
+import org.sani.algolog.global.error.exception.BadRequestException;
 import org.sani.algolog.global.common.BaseEntity;
 
 @Entity
@@ -38,7 +39,7 @@ public class Solution extends BaseEntity {
         this.code = code;
         this.timeElapsed = timeElapsed;
         this.isSolved = isSolved;
-        this.problem = problem;
+        this.problem = validateProblem(problem);
         this.member = member;
     }
 
@@ -46,6 +47,13 @@ public class Solution extends BaseEntity {
         this.code = code;
         this.timeElapsed = timeElapsed;
         this.isSolved = isSolved;
-        this.problem = problem;
+        this.problem = validateProblem(problem);
+    }
+
+    private Problem validateProblem(Problem problem) {
+        if (problem == null) {
+            throw new BadRequestException("Problem must not be null.");
+        }
+        return problem;
     }
 }

--- a/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
+++ b/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
@@ -4,6 +4,8 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.sani.algolog.domain.member.entity.Member;
 import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.domain.problem.entity.Problem;
+import org.sani.algolog.domain.problem.repository.ProblemRepository;
 import org.sani.algolog.domain.solution.dto.SolutionRequest;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
 import org.sani.algolog.domain.solution.entity.Solution;
@@ -21,11 +23,13 @@ public class SolutionService {
 
     private final SolutionRepository solutionRepository;
     private final MemberRepository memberRepository;
+    private final ProblemRepository problemRepository;
 
     @Transactional
     public SolutionResponse save(SolutionRequest request, Long memberId) {
         Member member = findMember(memberId);
-        Solution solution = request.toEntity(member);
+        Problem problem = findProblem(request.getProblemId());
+        Solution solution = request.toEntity(member, problem);
 
         Solution savedSolution = solutionRepository.save(solution);
         return SolutionResponse.from(savedSolution);
@@ -35,12 +39,13 @@ public class SolutionService {
     public SolutionResponse update(Long solutionId, SolutionRequest request, Long memberId) {
         Solution solution = findSolution(solutionId);
         validateOwner(solution, memberId);
+        Problem problem = findProblem(request.getProblemId());
 
         solution.update(
                 request.getCode(),
                 request.getTimeElapsed(),
                 request.getSolved(),
-                request.getProblemId()
+                problem
         );
 
         return SolutionResponse.from(solution);
@@ -74,6 +79,11 @@ public class SolutionService {
     private Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("Member not found: " + memberId));
+    }
+
+    private Problem findProblem(Long problemId) {
+        return problemRepository.findById(problemId)
+                .orElseThrow(() -> new EntityNotFoundException("Problem not found: " + problemId));
     }
 
     private void validateOwner(Solution solution, Long memberId) {

--- a/src/test/java/org/sani/algolog/domain/solution/repository/SolutionRepositoryTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/repository/SolutionRepositoryTest.java
@@ -6,6 +6,9 @@ import org.sani.algolog.domain.member.entity.Member;
 import org.sani.algolog.domain.member.entity.Provider;
 import org.sani.algolog.domain.member.entity.Role;
 import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.domain.problem.entity.Platform;
+import org.sani.algolog.domain.problem.entity.Problem;
+import org.sani.algolog.domain.problem.repository.ProblemRepository;
 import org.sani.algolog.domain.solution.entity.Solution;
 import org.sani.algolog.global.config.JpaConfig;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +29,9 @@ class SolutionRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private ProblemRepository problemRepository;
+
     @Test
     @DisplayName("풀이 저장 및 회원 연관관계 매핑 확인")
     void saveSolutionWithMember() {
@@ -36,12 +42,19 @@ class SolutionRepositoryTest {
                 .provider(Provider.GITHUB)
                 .role(Role.USER)
                 .build());
+        Problem problem = problemRepository.save(Problem.builder()
+                .platform(Platform.BOJ)
+                .externalProblemId("1000")
+                .title("A+B")
+                .problemUrl("https://www.acmicpc.net/problem/1000")
+                .difficulty("Bronze V")
+                .build());
 
         Solution solution = Solution.builder()
                 .code("public class Solution { }")
                 .timeElapsed(120)
                 .isSolved(true)
-                .problemId(1L)
+                .problem(problem)
                 .member(member)
                 .build();
 
@@ -51,6 +64,7 @@ class SolutionRepositoryTest {
         // then
         assertThat(savedSolution.getId()).isNotNull();
         assertThat(savedSolution.getMember().getId()).isEqualTo(member.getId());
+        assertThat(savedSolution.getProblem().getId()).isEqualTo(problem.getId());
         assertThat(savedSolution.getCreatedAt()).isNotNull();
     }
 
@@ -64,12 +78,19 @@ class SolutionRepositoryTest {
                 .provider(Provider.GITHUB)
                 .role(Role.USER)
                 .build());
+        Problem problem = problemRepository.save(Problem.builder()
+                .platform(Platform.BOJ)
+                .externalProblemId("1001")
+                .title("A-B")
+                .problemUrl("https://www.acmicpc.net/problem/1001")
+                .difficulty("Bronze V")
+                .build());
 
         solutionRepository.save(Solution.builder()
                 .code("class Solution { }")
                 .timeElapsed(300)
                 .isSolved(true)
-                .problemId(1L)
+                .problem(problem)
                 .member(member)
                 .build());
 
@@ -78,6 +99,6 @@ class SolutionRepositoryTest {
 
         // then
         assertThat(solutions).hasSize(1);
-        assertThat(solutions.get(0).getProblemId()).isEqualTo(1L);
+        assertThat(solutions.get(0).getProblem().getExternalProblemId()).isEqualTo("1001");
     }
 }

--- a/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
@@ -10,6 +10,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sani.algolog.domain.member.entity.Member;
 import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.domain.problem.entity.Platform;
+import org.sani.algolog.domain.problem.entity.Problem;
+import org.sani.algolog.domain.problem.repository.ProblemRepository;
 import org.sani.algolog.domain.solution.dto.SolutionRequest;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
 import org.sani.algolog.domain.solution.entity.Solution;
@@ -36,6 +39,9 @@ class SolutionServiceTest {
     @Mock
     private MemberRepository memberRepository;
 
+    @Mock
+    private ProblemRepository problemRepository;
+
     @InjectMocks
     private SolutionService solutionService;
 
@@ -44,6 +50,7 @@ class SolutionServiceTest {
     void saveSolution() {
         Member member = mock(Member.class);
         when(member.getId()).thenReturn(1L);
+        Problem problem = problem(10L);
 
         SolutionRequest request = new SolutionRequest("code", 120, true, 10L);
 
@@ -51,12 +58,13 @@ class SolutionServiceTest {
                 .code("code")
                 .timeElapsed(120)
                 .isSolved(true)
-                .problemId(10L)
+                .problem(problem)
                 .member(member)
                 .build();
         ReflectionTestUtils.setField(savedSolution, "id", 100L);
 
         when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(problemRepository.findById(10L)).thenReturn(Optional.of(problem));
         when(solutionRepository.save(any(Solution.class))).thenReturn(savedSolution);
 
         SolutionResponse response = solutionService.save(request, 1L);
@@ -67,7 +75,7 @@ class SolutionServiceTest {
         assertThat(captured.getCode()).isEqualTo(request.getCode());
         assertThat(captured.getTimeElapsed()).isEqualTo(request.getTimeElapsed());
         assertThat(captured.isSolved()).isEqualTo(request.getSolved());
-        assertThat(captured.getProblemId()).isEqualTo(request.getProblemId());
+        assertThat(captured.getProblem()).isEqualTo(problem);
         assertThat(captured.getMember()).isEqualTo(member);
 
         assertThat(response.getId()).isEqualTo(100L);
@@ -81,17 +89,20 @@ class SolutionServiceTest {
     void updateSolution() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
+        Problem currentProblem = problem(5L);
+        Problem newProblem = problem(7L);
 
         Solution solution = Solution.builder()
                 .code("old")
                 .timeElapsed(30)
                 .isSolved(false)
-                .problemId(5L)
+                .problem(currentProblem)
                 .member(owner)
                 .build();
         ReflectionTestUtils.setField(solution, "id", 1L);
 
         when(solutionRepository.findById(1L)).thenReturn(Optional.of(solution));
+        when(problemRepository.findById(7L)).thenReturn(Optional.of(newProblem));
 
         SolutionRequest request = new SolutionRequest("new", 60, true, 7L);
         SolutionResponse response = solutionService.update(1L, request, 1L);
@@ -99,7 +110,7 @@ class SolutionServiceTest {
         assertThat(solution.getCode()).isEqualTo("new");
         assertThat(solution.getTimeElapsed()).isEqualTo(60);
         assertThat(solution.isSolved()).isTrue();
-        assertThat(solution.getProblemId()).isEqualTo(7L);
+        assertThat(solution.getProblem()).isEqualTo(newProblem);
         assertThat(response.getId()).isEqualTo(1L);
         assertThat(response.getProblemId()).isEqualTo(7L);
     }
@@ -109,12 +120,13 @@ class SolutionServiceTest {
     void updateSolutionAccessDenied() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
+        Problem problem = problem(5L);
 
         Solution solution = Solution.builder()
                 .code("old")
                 .timeElapsed(30)
                 .isSolved(false)
-                .problemId(5L)
+                .problem(problem)
                 .member(owner)
                 .build();
 
@@ -131,12 +143,13 @@ class SolutionServiceTest {
     void deleteSolution() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
+        Problem problem = problem(5L);
 
         Solution solution = Solution.builder()
                 .code("code")
                 .timeElapsed(30)
                 .isSolved(true)
-                .problemId(5L)
+                .problem(problem)
                 .member(owner)
                 .build();
 
@@ -152,12 +165,13 @@ class SolutionServiceTest {
     void deleteSolutionAccessDenied() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
+        Problem problem = problem(5L);
 
         Solution solution = Solution.builder()
                 .code("code")
                 .timeElapsed(30)
                 .isSolved(true)
-                .problemId(5L)
+                .problem(problem)
                 .member(owner)
                 .build();
 
@@ -172,12 +186,13 @@ class SolutionServiceTest {
     void getSolutionsByMember() {
         Member member = mock(Member.class);
         when(member.getId()).thenReturn(3L);
+        Problem problem = problem(2L);
 
         Solution solution = Solution.builder()
                 .code("code")
                 .timeElapsed(10)
                 .isSolved(true)
-                .problemId(2L)
+                .problem(problem)
                 .member(member)
                 .build();
         ReflectionTestUtils.setField(solution, "id", 99L);
@@ -206,12 +221,13 @@ class SolutionServiceTest {
     void getSolutionById() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
+        Problem problem = problem(2L);
 
         Solution solution = Solution.builder()
                 .code("code")
                 .timeElapsed(10)
                 .isSolved(true)
-                .problemId(2L)
+                .problem(problem)
                 .member(owner)
                 .build();
         ReflectionTestUtils.setField(solution, "id", 7L);
@@ -229,12 +245,13 @@ class SolutionServiceTest {
     void getSolutionByIdAccessDenied() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
+        Problem problem = problem(2L);
 
         Solution solution = Solution.builder()
                 .code("code")
                 .timeElapsed(10)
                 .isSolved(true)
-                .problemId(2L)
+                .problem(problem)
                 .member(owner)
                 .build();
         ReflectionTestUtils.setField(solution, "id", 7L);
@@ -254,5 +271,17 @@ class SolutionServiceTest {
 
         assertThatThrownBy(() -> solutionService.update(1L, request, 1L))
                 .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    private Problem problem(Long id) {
+        Problem problem = Problem.builder()
+                .platform(Platform.BOJ)
+                .externalProblemId(String.valueOf(id))
+                .title("problem-" + id)
+                .problemUrl("https://example.com/problems/" + id)
+                .difficulty("Bronze")
+                .build();
+        ReflectionTestUtils.setField(problem, "id", id);
+        return problem;
     }
 }

--- a/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
@@ -17,6 +17,7 @@ import org.sani.algolog.domain.solution.dto.SolutionRequest;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
 import org.sani.algolog.domain.solution.entity.Solution;
 import org.sani.algolog.domain.solution.repository.SolutionRepository;
+import org.sani.algolog.global.error.exception.BadRequestException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -271,6 +272,39 @@ class SolutionServiceTest {
 
         assertThatThrownBy(() -> solutionService.update(1L, request, 1L))
                 .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("solution creation rejects null problem")
+    void createSolutionWithNullProblem() {
+        Member member = mock(Member.class);
+
+        assertThatThrownBy(() -> Solution.builder()
+                .code("code")
+                .timeElapsed(10)
+                .isSolved(true)
+                .problem(null)
+                .member(member)
+                .build())
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Problem must not be null.");
+    }
+
+    @Test
+    @DisplayName("solution update rejects null problem")
+    void updateSolutionWithNullProblem() {
+        Member member = mock(Member.class);
+        Solution solution = Solution.builder()
+                .code("code")
+                .timeElapsed(10)
+                .isSolved(true)
+                .problem(problem(1L))
+                .member(member)
+                .build();
+
+        assertThatThrownBy(() -> solution.update("new code", 20, true, null))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Problem must not be null.");
     }
 
     private Problem problem(Long id) {


### PR DESCRIPTION
## 🔗 관련 이슈 (Issue)
Closes #16

## ✅ 주요 작업 내용 (Changes)
- [x] `Solution.problemId` 필드를 `Problem` 연관관계로 전환
- [x] `SolutionRequest` 저장 흐름이 `Problem` 엔티티를 참조하도록 변경
- [x] `SolutionResponse`는 기존 계약을 유지하면서 내부 연관관계에서 `problemId`를 노출하도록 조정
- [x] `SolutionService`에 `ProblemRepository` 연동 및 문제 조회 로직 추가
- [x] 서비스/리포지토리 테스트를 연관관계 기준으로 갱신

## 📸 스크린샷 (Optional)
- 없음

## ✅ 셀프 체크리스트 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그와 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 🔎 리뷰 포인트 (Review Point)
- 이번 PR은 외부 API 계약을 유지한 채 내부 도메인 관계만 전환했습니다. 이후 `#17`에서 DTO 구조를 확장할 때 이 분리가 적절한지 확인 부탁드립니다.
- `SolutionResponse`가 계속 `problemId`만 노출하는 현재 정책이 단계적 변경 관점에서 적절한지 확인 부탁드립니다.
