### PR TITLE
[FEAT] 수동 문제 풀이 등록용 Solution DTO 및 저장 흐름 재설계

### DIFF
--- a/src/main/java/org/sani/algolog/domain/problem/dto/ProblemRequest.java
+++ b/src/main/java/org/sani/algolog/domain/problem/dto/ProblemRequest.java
@@ -1,0 +1,40 @@
+package org.sani.algolog.domain.problem.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sani.algolog.domain.problem.entity.Platform;
+import org.sani.algolog.domain.problem.entity.Problem;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProblemRequest {
+
+    @NotNull
+    private Platform platform;
+
+    @NotBlank
+    private String externalProblemId;
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String problemUrl;
+
+    @NotBlank
+    private String difficulty;
+
+    public Problem toEntity() {
+        return Problem.builder()
+                .platform(platform)
+                .externalProblemId(externalProblemId)
+                .title(title)
+                .problemUrl(problemUrl)
+                .difficulty(difficulty)
+                .build();
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/problem/dto/ProblemRequest.java
+++ b/src/main/java/org/sani/algolog/domain/problem/dto/ProblemRequest.java
@@ -2,6 +2,7 @@ package org.sani.algolog.domain.problem.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,15 +18,19 @@ public class ProblemRequest {
     private Platform platform;
 
     @NotBlank
+    @Size(max = 100)
     private String externalProblemId;
 
     @NotBlank
+    @Size(max = 255)
     private String title;
 
     @NotBlank
+    @Size(max = 500)
     private String problemUrl;
 
     @NotBlank
+    @Size(max = 50)
     private String difficulty;
 
     public Problem toEntity() {

--- a/src/main/java/org/sani/algolog/domain/problem/dto/ProblemResponse.java
+++ b/src/main/java/org/sani/algolog/domain/problem/dto/ProblemResponse.java
@@ -1,0 +1,29 @@
+package org.sani.algolog.domain.problem.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.sani.algolog.domain.problem.entity.Platform;
+import org.sani.algolog.domain.problem.entity.Problem;
+
+@Getter
+@Builder
+public class ProblemResponse {
+
+    private Long id;
+    private Platform platform;
+    private String externalProblemId;
+    private String title;
+    private String problemUrl;
+    private String difficulty;
+
+    public static ProblemResponse from(Problem problem) {
+        return ProblemResponse.builder()
+                .id(problem.getId())
+                .platform(problem.getPlatform())
+                .externalProblemId(problem.getExternalProblemId())
+                .title(problem.getTitle())
+                .problemUrl(problem.getProblemUrl())
+                .difficulty(problem.getDifficulty())
+                .build();
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/problem/service/ProblemService.java
+++ b/src/main/java/org/sani/algolog/domain/problem/service/ProblemService.java
@@ -1,0 +1,25 @@
+package org.sani.algolog.domain.problem.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.domain.problem.dto.ProblemRequest;
+import org.sani.algolog.domain.problem.entity.Problem;
+import org.sani.algolog.domain.problem.repository.ProblemRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemService {
+
+    private final ProblemRepository problemRepository;
+
+    @Transactional
+    public Problem getOrCreate(ProblemRequest request) {
+        return problemRepository.findByPlatformAndExternalProblemId(
+                        request.getPlatform(),
+                        request.getExternalProblemId()
+                )
+                .orElseGet(() -> problemRepository.save(request.toEntity()));
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/problem/service/ProblemService.java
+++ b/src/main/java/org/sani/algolog/domain/problem/service/ProblemService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.sani.algolog.domain.problem.dto.ProblemRequest;
 import org.sani.algolog.domain.problem.entity.Problem;
 import org.sani.algolog.domain.problem.repository.ProblemRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,18 @@ public class ProblemService {
                         request.getPlatform(),
                         request.getExternalProblemId()
                 )
-                .orElseGet(() -> problemRepository.save(request.toEntity()));
+                .orElseGet(() -> saveOrFindExisting(request));
+    }
+
+    private Problem saveOrFindExisting(ProblemRequest request) {
+        try {
+            return problemRepository.saveAndFlush(request.toEntity());
+        } catch (DataIntegrityViolationException exception) {
+            return problemRepository.findByPlatformAndExternalProblemId(
+                            request.getPlatform(),
+                            request.getExternalProblemId()
+                    )
+                    .orElseThrow(() -> exception);
+        }
     }
 }

--- a/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
+++ b/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.sani.algolog.domain.solution.dto.SolutionRequest;
+import org.sani.algolog.domain.solution.dto.SolutionCreateRequest;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
 import org.sani.algolog.domain.solution.service.SolutionService;
 import org.sani.algolog.global.common.ApiResponse;
@@ -32,7 +32,7 @@ public class SolutionController {
     @PostMapping
     public ApiResponse<SolutionResponse> save(
             @RequestHeader(MEMBER_ID_HEADER) Long memberId,
-            @Valid @RequestBody SolutionRequest request
+            @Valid @RequestBody SolutionCreateRequest request
     ) {
         return ApiResponse.success(solutionService.save(request, memberId));
     }

--- a/src/main/java/org/sani/algolog/domain/solution/dto/SolutionCreateRequest.java
+++ b/src/main/java/org/sani/algolog/domain/solution/dto/SolutionCreateRequest.java
@@ -1,5 +1,6 @@
 package org.sani.algolog.domain.solution.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -7,13 +8,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.problem.dto.ProblemRequest;
 import org.sani.algolog.domain.problem.entity.Problem;
 import org.sani.algolog.domain.solution.entity.Solution;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class SolutionRequest {
+public class SolutionCreateRequest {
 
     @NotBlank
     private String code;
@@ -25,14 +27,19 @@ public class SolutionRequest {
     @NotNull
     private Boolean solved;
 
-    @NotNull
-    private Long problemId;
+    @NotBlank
+    private String memoMarkdown;
 
-    public Solution toEntity(Member member, Problem problem){
+    @Valid
+    @NotNull
+    private ProblemRequest problem;
+
+    public Solution toEntity(Member member, Problem problem) {
         return Solution.builder()
-                .code(this.getCode())
-                .timeElapsed(this.getTimeElapsed())
-                .isSolved(this.getSolved())
+                .code(code)
+                .timeElapsed(timeElapsed)
+                .isSolved(solved)
+                .memoMarkdown(memoMarkdown)
                 .problem(problem)
                 .member(member)
                 .build();

--- a/src/main/java/org/sani/algolog/domain/solution/dto/SolutionResponse.java
+++ b/src/main/java/org/sani/algolog/domain/solution/dto/SolutionResponse.java
@@ -2,6 +2,7 @@ package org.sani.algolog.domain.solution.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.sani.algolog.domain.problem.dto.ProblemResponse;
 import org.sani.algolog.domain.solution.entity.Solution;
 
 import java.time.LocalDateTime;
@@ -14,7 +15,8 @@ public class SolutionResponse {
     private String code;
     private Integer timeElapsed;
     private boolean solved;
-    private Long problemId;
+    private String memoMarkdown;
+    private ProblemResponse problem;
     private Long memberId;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -25,7 +27,8 @@ public class SolutionResponse {
                 .code(solution.getCode())
                 .timeElapsed(solution.getTimeElapsed())
                 .solved(solution.isSolved())
-                .problemId(solution.getProblem().getId())
+                .memoMarkdown(solution.getMemoMarkdown())
+                .problem(ProblemResponse.from(solution.getProblem()))
                 .memberId(solution.getMember().getId())
                 .createdAt(solution.getCreatedAt())
                 .updatedAt(solution.getUpdatedAt())

--- a/src/main/java/org/sani/algolog/domain/solution/dto/SolutionUpdateRequest.java
+++ b/src/main/java/org/sani/algolog/domain/solution/dto/SolutionUpdateRequest.java
@@ -1,0 +1,27 @@
+package org.sani.algolog.domain.solution.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SolutionUpdateRequest {
+
+    @NotBlank
+    private String code;
+
+    @NotNull
+    @Min(0)
+    private Integer timeElapsed;
+
+    @NotNull
+    private Boolean solved;
+
+    @NotBlank
+    private String memoMarkdown;
+}

--- a/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
+++ b/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
@@ -26,6 +26,10 @@ public class Solution extends BaseEntity {
 
     private boolean isSolved;
 
+    @Lob
+    @Column(nullable = false)
+    private String memoMarkdown;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -35,19 +39,27 @@ public class Solution extends BaseEntity {
     private Problem problem;
 
     @Builder
-    public Solution(String code, Integer timeElapsed, boolean isSolved, Problem problem, Member member) {
+    public Solution(
+            String code,
+            Integer timeElapsed,
+            boolean isSolved,
+            String memoMarkdown,
+            Problem problem,
+            Member member
+    ) {
         this.code = code;
         this.timeElapsed = timeElapsed;
         this.isSolved = isSolved;
+        this.memoMarkdown = memoMarkdown;
         this.problem = validateProblem(problem);
         this.member = member;
     }
 
-    public void update(String code, Integer timeElapsed, boolean isSolved, Problem problem) {
+    public void update(String code, Integer timeElapsed, boolean isSolved, String memoMarkdown) {
         this.code = code;
         this.timeElapsed = timeElapsed;
         this.isSolved = isSolved;
-        this.problem = validateProblem(problem);
+        this.memoMarkdown = memoMarkdown;
     }
 
     private Problem validateProblem(Problem problem) {

--- a/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
+++ b/src/main/java/org/sani/algolog/domain/solution/entity/Solution.java
@@ -27,7 +27,7 @@ public class Solution extends BaseEntity {
     private boolean isSolved;
 
     @Lob
-    @Column(nullable = false)
+    @Column
     private String memoMarkdown;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/sani/algolog/domain/solution/repository/SolutionRepository.java
+++ b/src/main/java/org/sani/algolog/domain/solution/repository/SolutionRepository.java
@@ -2,6 +2,7 @@ package org.sani.algolog.domain.solution.repository;
 
 import org.sani.algolog.domain.solution.entity.Solution;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,7 +10,21 @@ import java.util.Optional;
 public interface SolutionRepository extends JpaRepository<Solution, Long> {
     List<Solution> findAllByMemberId(Long memberId);
 
+    @Query("""
+            select s
+            from Solution s
+            join fetch s.problem p
+            where s.member.id = :memberId
+            order by s.createdAt desc
+            """)
     List<Solution> findAllByMemberIdOrderByCreatedAtDesc(Long memberId);
 
+    @Query("""
+            select s
+            from Solution s
+            join fetch s.problem p
+            where s.id = :id
+              and s.member.id = :memberId
+            """)
     Optional<Solution> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
+++ b/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
@@ -66,8 +66,9 @@ public class SolutionService {
     }
 
     public SolutionResponse getSolution(Long solutionId, Long memberId) {
-        Solution solution = findSolution(solutionId);
-        validateOwner(solution, memberId);
+        findMember(memberId);
+        Solution solution = solutionRepository.findByIdAndMemberId(solutionId, memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Solution not found: " + solutionId));
         return SolutionResponse.from(solution);
     }
 

--- a/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
+++ b/src/main/java/org/sani/algolog/domain/solution/service/SolutionService.java
@@ -5,9 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.sani.algolog.domain.member.entity.Member;
 import org.sani.algolog.domain.member.repository.MemberRepository;
 import org.sani.algolog.domain.problem.entity.Problem;
-import org.sani.algolog.domain.problem.repository.ProblemRepository;
-import org.sani.algolog.domain.solution.dto.SolutionRequest;
+import org.sani.algolog.domain.problem.service.ProblemService;
+import org.sani.algolog.domain.solution.dto.SolutionCreateRequest;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
+import org.sani.algolog.domain.solution.dto.SolutionUpdateRequest;
 import org.sani.algolog.domain.solution.entity.Solution;
 import org.sani.algolog.domain.solution.repository.SolutionRepository;
 import org.springframework.security.access.AccessDeniedException;
@@ -23,12 +24,12 @@ public class SolutionService {
 
     private final SolutionRepository solutionRepository;
     private final MemberRepository memberRepository;
-    private final ProblemRepository problemRepository;
+    private final ProblemService problemService;
 
     @Transactional
-    public SolutionResponse save(SolutionRequest request, Long memberId) {
+    public SolutionResponse save(SolutionCreateRequest request, Long memberId) {
         Member member = findMember(memberId);
-        Problem problem = findProblem(request.getProblemId());
+        Problem problem = problemService.getOrCreate(request.getProblem());
         Solution solution = request.toEntity(member, problem);
 
         Solution savedSolution = solutionRepository.save(solution);
@@ -36,16 +37,15 @@ public class SolutionService {
     }
 
     @Transactional
-    public SolutionResponse update(Long solutionId, SolutionRequest request, Long memberId) {
+    public SolutionResponse update(Long solutionId, SolutionUpdateRequest request, Long memberId) {
         Solution solution = findSolution(solutionId);
         validateOwner(solution, memberId);
-        Problem problem = findProblem(request.getProblemId());
 
         solution.update(
                 request.getCode(),
                 request.getTimeElapsed(),
                 request.getSolved(),
-                problem
+                request.getMemoMarkdown()
         );
 
         return SolutionResponse.from(solution);
@@ -79,11 +79,6 @@ public class SolutionService {
     private Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("Member not found: " + memberId));
-    }
-
-    private Problem findProblem(Long problemId) {
-        return problemRepository.findById(problemId)
-                .orElseThrow(() -> new EntityNotFoundException("Problem not found: " + problemId));
     }
 
     private void validateOwner(Solution solution, Long memberId) {

--- a/src/test/java/org/sani/algolog/domain/problem/service/ProblemServiceTest.java
+++ b/src/test/java/org/sani/algolog/domain/problem/service/ProblemServiceTest.java
@@ -1,0 +1,78 @@
+package org.sani.algolog.domain.problem.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sani.algolog.domain.problem.dto.ProblemRequest;
+import org.sani.algolog.domain.problem.entity.Platform;
+import org.sani.algolog.domain.problem.entity.Problem;
+import org.sani.algolog.domain.problem.repository.ProblemRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProblemServiceTest {
+
+    @Mock
+    private ProblemRepository problemRepository;
+
+    @InjectMocks
+    private ProblemService problemService;
+
+    @Test
+    @DisplayName("existing problem is reused")
+    void getOrCreateReturnsExistingProblem() {
+        ProblemRequest request = request();
+        Problem existingProblem = problem(1L);
+
+        when(problemRepository.findByPlatformAndExternalProblemId(Platform.BOJ, "1000"))
+                .thenReturn(Optional.of(existingProblem));
+
+        Problem result = problemService.getOrCreate(request);
+
+        assertThat(result).isEqualTo(existingProblem);
+    }
+
+    @Test
+    @DisplayName("duplicate insert falls back to existing problem")
+    void getOrCreateFallsBackAfterDuplicateInsert() {
+        ProblemRequest request = request();
+        Problem existingProblem = problem(1L);
+
+        when(problemRepository.findByPlatformAndExternalProblemId(Platform.BOJ, "1000"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(existingProblem));
+        when(problemRepository.saveAndFlush(org.mockito.ArgumentMatchers.any(Problem.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate key"));
+
+        Problem result = problemService.getOrCreate(request);
+
+        assertThat(result).isEqualTo(existingProblem);
+        verify(problemRepository).saveAndFlush(org.mockito.ArgumentMatchers.any(Problem.class));
+    }
+
+    private ProblemRequest request() {
+        return new ProblemRequest(
+                Platform.BOJ,
+                "1000",
+                "A+B",
+                "https://www.acmicpc.net/problem/1000",
+                "Bronze V"
+        );
+    }
+
+    private Problem problem(Long id) {
+        Problem problem = request().toEntity();
+        ReflectionTestUtils.setField(problem, "id", id);
+        return problem;
+    }
+}

--- a/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
@@ -3,6 +3,8 @@ package org.sani.algolog.domain.solution.controller;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.sani.algolog.domain.problem.dto.ProblemResponse;
+import org.sani.algolog.domain.problem.entity.Platform;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
 import org.sani.algolog.domain.solution.service.SolutionService;
 import org.sani.algolog.global.error.GlobalExceptionHandler;
@@ -51,7 +53,14 @@ class SolutionControllerTest {
                   "code": "public class Main {}",
                   "timeElapsed": 123,
                   "solved": true,
-                  "problemId": 10
+                  "memoMarkdown": "## 회고\\n- DP 점화식을 다시 복습해야 한다.",
+                  "problem": {
+                    "platform": "BOJ",
+                    "externalProblemId": "1000",
+                    "title": "A+B",
+                    "problemUrl": "https://www.acmicpc.net/problem/1000",
+                    "difficulty": "Bronze V"
+                  }
                 }
                 """;
 
@@ -64,7 +73,9 @@ class SolutionControllerTest {
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.id").value(100))
                 .andExpect(jsonPath("$.data.memberId").value(1))
-                .andExpect(jsonPath("$.data.problemId").value(10));
+                .andExpect(jsonPath("$.data.problem.id").value(10))
+                .andExpect(jsonPath("$.data.problem.platform").value("BOJ"))
+                .andExpect(jsonPath("$.data.memoMarkdown").value("회고"));
     }
 
     @Test
@@ -74,7 +85,11 @@ class SolutionControllerTest {
                 {
                   "code": "",
                   "timeElapsed": -1,
-                  "solved": null
+                  "solved": null,
+                  "memoMarkdown": "",
+                  "problem": {
+                    "title": ""
+                  }
                 }
                 """;
 
@@ -114,7 +129,8 @@ class SolutionControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.id").value(100));
+                .andExpect(jsonPath("$.data.id").value(100))
+                .andExpect(jsonPath("$.data.problem.title").value("A+B"));
     }
 
     @Test
@@ -159,7 +175,15 @@ class SolutionControllerTest {
                 .code("public class Main {}")
                 .timeElapsed(120)
                 .solved(true)
-                .problemId(problemId)
+                .memoMarkdown("회고")
+                .problem(ProblemResponse.builder()
+                        .id(problemId)
+                        .platform(Platform.BOJ)
+                        .externalProblemId("1000")
+                        .title("A+B")
+                        .problemUrl("https://www.acmicpc.net/problem/1000")
+                        .difficulty("Bronze V")
+                        .build())
                 .memberId(memberId)
                 .createdAt(now)
                 .updatedAt(now)

--- a/src/test/java/org/sani/algolog/domain/solution/repository/SolutionRepositoryTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/repository/SolutionRepositoryTest.java
@@ -54,6 +54,7 @@ class SolutionRepositoryTest {
                 .code("public class Solution { }")
                 .timeElapsed(120)
                 .isSolved(true)
+                .memoMarkdown("기본 입출력 회고")
                 .problem(problem)
                 .member(member)
                 .build();
@@ -90,6 +91,7 @@ class SolutionRepositoryTest {
                 .code("class Solution { }")
                 .timeElapsed(300)
                 .isSolved(true)
+                .memoMarkdown("입출력 풀이")
                 .problem(problem)
                 .member(member)
                 .build());

--- a/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
@@ -253,7 +253,8 @@ class SolutionServiceTest {
                 .build();
         ReflectionTestUtils.setField(solution, "id", 7L);
 
-        when(solutionRepository.findById(7L)).thenReturn(Optional.of(solution));
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(owner));
+        when(solutionRepository.findByIdAndMemberId(7L, 1L)).thenReturn(Optional.of(solution));
 
         SolutionResponse response = solutionService.getSolution(7L, 1L);
 
@@ -263,10 +264,9 @@ class SolutionServiceTest {
     }
 
     @Test
-    @DisplayName("get solution detail is denied for non-owner")
+    @DisplayName("get solution detail raises not found for non-owner")
     void getSolutionByIdAccessDenied() {
         Member owner = mock(Member.class);
-        when(owner.getId()).thenReturn(1L);
         Problem problem = problem(2L);
 
         Solution solution = Solution.builder()
@@ -279,10 +279,11 @@ class SolutionServiceTest {
                 .build();
         ReflectionTestUtils.setField(solution, "id", 7L);
 
-        when(solutionRepository.findById(7L)).thenReturn(Optional.of(solution));
+        when(memberRepository.findById(99L)).thenReturn(Optional.of(owner));
+        when(solutionRepository.findByIdAndMemberId(7L, 99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> solutionService.getSolution(7L, 99L))
-                .isInstanceOf(AccessDeniedException.class);
+                .isInstanceOf(EntityNotFoundException.class);
     }
 
     @Test

--- a/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/service/SolutionServiceTest.java
@@ -10,11 +10,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sani.algolog.domain.member.entity.Member;
 import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.domain.problem.dto.ProblemRequest;
 import org.sani.algolog.domain.problem.entity.Platform;
 import org.sani.algolog.domain.problem.entity.Problem;
-import org.sani.algolog.domain.problem.repository.ProblemRepository;
-import org.sani.algolog.domain.solution.dto.SolutionRequest;
+import org.sani.algolog.domain.problem.service.ProblemService;
+import org.sani.algolog.domain.solution.dto.SolutionCreateRequest;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
+import org.sani.algolog.domain.solution.dto.SolutionUpdateRequest;
 import org.sani.algolog.domain.solution.entity.Solution;
 import org.sani.algolog.domain.solution.repository.SolutionRepository;
 import org.sani.algolog.global.error.exception.BadRequestException;
@@ -41,7 +43,7 @@ class SolutionServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private ProblemRepository problemRepository;
+    private ProblemService problemService;
 
     @InjectMocks
     private SolutionService solutionService;
@@ -53,19 +55,32 @@ class SolutionServiceTest {
         when(member.getId()).thenReturn(1L);
         Problem problem = problem(10L);
 
-        SolutionRequest request = new SolutionRequest("code", 120, true, 10L);
+        SolutionCreateRequest request = new SolutionCreateRequest(
+                "code",
+                120,
+                true,
+                "회고",
+                new ProblemRequest(
+                        Platform.BOJ,
+                        "1000",
+                        "A+B",
+                        "https://www.acmicpc.net/problem/1000",
+                        "Bronze V"
+                )
+        );
 
         Solution savedSolution = Solution.builder()
                 .code("code")
                 .timeElapsed(120)
                 .isSolved(true)
+                .memoMarkdown("회고")
                 .problem(problem)
                 .member(member)
                 .build();
         ReflectionTestUtils.setField(savedSolution, "id", 100L);
 
         when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-        when(problemRepository.findById(10L)).thenReturn(Optional.of(problem));
+        when(problemService.getOrCreate(request.getProblem())).thenReturn(problem);
         when(solutionRepository.save(any(Solution.class))).thenReturn(savedSolution);
 
         SolutionResponse response = solutionService.save(request, 1L);
@@ -76,11 +91,12 @@ class SolutionServiceTest {
         assertThat(captured.getCode()).isEqualTo(request.getCode());
         assertThat(captured.getTimeElapsed()).isEqualTo(request.getTimeElapsed());
         assertThat(captured.isSolved()).isEqualTo(request.getSolved());
+        assertThat(captured.getMemoMarkdown()).isEqualTo(request.getMemoMarkdown());
         assertThat(captured.getProblem()).isEqualTo(problem);
         assertThat(captured.getMember()).isEqualTo(member);
 
         assertThat(response.getId()).isEqualTo(100L);
-        assertThat(response.getProblemId()).isEqualTo(10L);
+        assertThat(response.getProblem().getId()).isEqualTo(10L);
         assertThat(response.isSolved()).isTrue();
         assertThat(response.getMemberId()).isEqualTo(1L);
     }
@@ -91,29 +107,29 @@ class SolutionServiceTest {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
         Problem currentProblem = problem(5L);
-        Problem newProblem = problem(7L);
 
         Solution solution = Solution.builder()
                 .code("old")
                 .timeElapsed(30)
                 .isSolved(false)
+                .memoMarkdown("old memo")
                 .problem(currentProblem)
                 .member(owner)
                 .build();
         ReflectionTestUtils.setField(solution, "id", 1L);
 
         when(solutionRepository.findById(1L)).thenReturn(Optional.of(solution));
-        when(problemRepository.findById(7L)).thenReturn(Optional.of(newProblem));
 
-        SolutionRequest request = new SolutionRequest("new", 60, true, 7L);
+        SolutionUpdateRequest request = new SolutionUpdateRequest("new", 60, true, "new memo");
         SolutionResponse response = solutionService.update(1L, request, 1L);
 
         assertThat(solution.getCode()).isEqualTo("new");
         assertThat(solution.getTimeElapsed()).isEqualTo(60);
         assertThat(solution.isSolved()).isTrue();
-        assertThat(solution.getProblem()).isEqualTo(newProblem);
+        assertThat(solution.getMemoMarkdown()).isEqualTo("new memo");
+        assertThat(solution.getProblem()).isEqualTo(currentProblem);
         assertThat(response.getId()).isEqualTo(1L);
-        assertThat(response.getProblemId()).isEqualTo(7L);
+        assertThat(response.getProblem().getId()).isEqualTo(5L);
     }
 
     @Test
@@ -121,19 +137,18 @@ class SolutionServiceTest {
     void updateSolutionAccessDenied() {
         Member owner = mock(Member.class);
         when(owner.getId()).thenReturn(1L);
-        Problem problem = problem(5L);
-
         Solution solution = Solution.builder()
                 .code("old")
                 .timeElapsed(30)
                 .isSolved(false)
-                .problem(problem)
+                .memoMarkdown("old memo")
+                .problem(problem(5L))
                 .member(owner)
                 .build();
 
         when(solutionRepository.findById(1L)).thenReturn(Optional.of(solution));
 
-        SolutionRequest request = new SolutionRequest("new", 60, true, 7L);
+        SolutionUpdateRequest request = new SolutionUpdateRequest("new", 60, true, "new memo");
 
         assertThatThrownBy(() -> solutionService.update(1L, request, 2L))
                 .isInstanceOf(AccessDeniedException.class);
@@ -150,6 +165,7 @@ class SolutionServiceTest {
                 .code("code")
                 .timeElapsed(30)
                 .isSolved(true)
+                .memoMarkdown("memo")
                 .problem(problem)
                 .member(owner)
                 .build();
@@ -172,6 +188,7 @@ class SolutionServiceTest {
                 .code("code")
                 .timeElapsed(30)
                 .isSolved(true)
+                .memoMarkdown("memo")
                 .problem(problem)
                 .member(owner)
                 .build();
@@ -193,6 +210,7 @@ class SolutionServiceTest {
                 .code("code")
                 .timeElapsed(10)
                 .isSolved(true)
+                .memoMarkdown("memo")
                 .problem(problem)
                 .member(member)
                 .build();
@@ -206,6 +224,7 @@ class SolutionServiceTest {
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).getId()).isEqualTo(99L);
         assertThat(responses.get(0).getMemberId()).isEqualTo(3L);
+        assertThat(responses.get(0).getProblem().getId()).isEqualTo(2L);
     }
 
     @Test
@@ -228,6 +247,7 @@ class SolutionServiceTest {
                 .code("code")
                 .timeElapsed(10)
                 .isSolved(true)
+                .memoMarkdown("memo")
                 .problem(problem)
                 .member(owner)
                 .build();
@@ -239,6 +259,7 @@ class SolutionServiceTest {
 
         assertThat(response.getId()).isEqualTo(7L);
         assertThat(response.getMemberId()).isEqualTo(1L);
+        assertThat(response.getProblem().getId()).isEqualTo(2L);
     }
 
     @Test
@@ -252,6 +273,7 @@ class SolutionServiceTest {
                 .code("code")
                 .timeElapsed(10)
                 .isSolved(true)
+                .memoMarkdown("memo")
                 .problem(problem)
                 .member(owner)
                 .build();
@@ -268,7 +290,7 @@ class SolutionServiceTest {
     void findSolutionNotFound() {
         when(solutionRepository.findById(1L)).thenReturn(Optional.empty());
 
-        SolutionRequest request = new SolutionRequest("code", 10, true, 2L);
+        SolutionUpdateRequest request = new SolutionUpdateRequest("code", 10, true, "memo");
 
         assertThatThrownBy(() -> solutionService.update(1L, request, 1L))
                 .isInstanceOf(EntityNotFoundException.class);
@@ -283,6 +305,7 @@ class SolutionServiceTest {
                 .code("code")
                 .timeElapsed(10)
                 .isSolved(true)
+                .memoMarkdown("memo")
                 .problem(null)
                 .member(member)
                 .build())
@@ -291,20 +314,23 @@ class SolutionServiceTest {
     }
 
     @Test
-    @DisplayName("solution update rejects null problem")
-    void updateSolutionWithNullProblem() {
+    @DisplayName("solution update keeps existing problem relation")
+    void updateSolutionKeepsExistingProblem() {
         Member member = mock(Member.class);
+        Problem problem = problem(1L);
         Solution solution = Solution.builder()
                 .code("code")
                 .timeElapsed(10)
                 .isSolved(true)
-                .problem(problem(1L))
+                .memoMarkdown("memo")
+                .problem(problem)
                 .member(member)
                 .build();
 
-        assertThatThrownBy(() -> solution.update("new code", 20, true, null))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessage("Problem must not be null.");
+        solution.update("new code", 20, true, "updated memo");
+
+        assertThat(solution.getProblem()).isEqualTo(problem);
+        assertThat(solution.getMemoMarkdown()).isEqualTo("updated memo");
     }
 
     private Problem problem(Long id) {


### PR DESCRIPTION
## 🔗 관련 이슈 (Issue)
Closes #17

## ✅ 주요 작업 내용 (Changes)
- [x] `SolutionCreateRequest`, `SolutionUpdateRequest`로 DTO 분리
- [x] 문제 메타데이터를 함께 받는 `ProblemRequest` / `ProblemResponse` 추가
- [x] `ProblemService#getOrCreate()`를 도입해 문제 upsert 후 풀이 저장 흐름 구현
- [x] `Solution`에 `memoMarkdown` 필드 추가
- [x] `SolutionResponse`가 문제 메타데이터와 회고를 함께 반환하도록 조정
- [x] 컨트롤러/서비스/리포지토리 테스트를 새 저장 흐름에 맞춰 갱신

## 📸 스크린샷 (Optional)
- 없음

## ✅ 셀프 체크리스트 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그와 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 🔎 리뷰 포인트 (Review Point)
- 수동 등록 시 `Problem`은 생성 또는 재사용하고, `Solution` 수정에서는 문제를 바꾸지 않는 현재 경계가 적절한지 확인 부탁드립니다.
- `SolutionResponse`를 중첩 `problem` 객체 구조로 확장한 변경이 이후 API 사용성 측면에서 적절한지 확인 부탁드립니다.
