### PR TITLE
[FEAT] Solution 수정 및 삭제 API 노출

### DIFF
--- a/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
+++ b/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
@@ -6,11 +6,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sani.algolog.domain.solution.dto.SolutionCreateRequest;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
+import org.sani.algolog.domain.solution.dto.SolutionUpdateRequest;
 import org.sani.algolog.domain.solution.service.SolutionService;
 import org.sani.algolog.global.common.ApiResponse;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -52,5 +55,25 @@ public class SolutionController {
             @RequestHeader(MEMBER_ID_HEADER) Long memberId
     ) {
         return ApiResponse.success(solutionService.getSolution(id, memberId));
+    }
+
+    @Operation(summary = "Update solution", description = "Updates a solution only when owned by the member in X-Member-Id header.")
+    @PutMapping("/{id}")
+    public ApiResponse<SolutionResponse> update(
+            @PathVariable Long id,
+            @RequestHeader(MEMBER_ID_HEADER) Long memberId,
+            @Valid @RequestBody SolutionUpdateRequest request
+    ) {
+        return ApiResponse.success(solutionService.update(id, request, memberId));
+    }
+
+    @Operation(summary = "Delete solution", description = "Deletes a solution only when owned by the member in X-Member-Id header.")
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(
+            @PathVariable Long id,
+            @RequestHeader(MEMBER_ID_HEADER) Long memberId
+    ) {
+        solutionService.delete(id, memberId);
+        return ApiResponse.success();
     }
 }

--- a/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
@@ -22,9 +22,12 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -153,6 +156,117 @@ class SolutionControllerTest {
                 .thenThrow(new EntityNotFoundException("Solution not found: 100"));
 
         mockMvc.perform(get(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/solutions/{id} returns updated solution")
+    void updateSolution() throws Exception {
+        SolutionResponse response = solutionResponse(100L, 1L, 10L);
+        when(solutionService.update(eq(100L), any(), eq(1L))).thenReturn(response);
+
+        String body = """
+                {
+                  "code": "public class Main { public static void main(String[] args) {} }",
+                  "timeElapsed": 111,
+                  "solved": true,
+                  "memoMarkdown": "수정된 회고"
+                }
+                """;
+
+        mockMvc.perform(put(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.id").value(100))
+                .andExpect(jsonPath("$.data.problem.id").value(10));
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/solutions/{id} forbidden returns FORBIDDEN")
+    void updateSolutionForbidden() throws Exception {
+        when(solutionService.update(eq(100L), any(), eq(1L)))
+                .thenThrow(new AccessDeniedException("작성자만 수정/삭제할 수 있습니다."));
+
+        String body = """
+                {
+                  "code": "public class Main {}",
+                  "timeElapsed": 120,
+                  "solved": true,
+                  "memoMarkdown": "회고"
+                }
+                """;
+
+        mockMvc.perform(put(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/solutions/{id} missing returns NOT_FOUND")
+    void updateSolutionNotFound() throws Exception {
+        when(solutionService.update(eq(100L), any(), eq(1L)))
+                .thenThrow(new EntityNotFoundException("Solution not found: 100"));
+
+        String body = """
+                {
+                  "code": "public class Main {}",
+                  "timeElapsed": 120,
+                  "solved": true,
+                  "memoMarkdown": "회고"
+                }
+                """;
+
+        mockMvc.perform(put(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/solutions/{id} returns SUCCESS")
+    void deleteSolution() throws Exception {
+        mockMvc.perform(delete(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/solutions/{id} forbidden returns FORBIDDEN")
+    void deleteSolutionForbidden() throws Exception {
+        doThrow(new AccessDeniedException("작성자만 수정/삭제할 수 있습니다."))
+                .when(solutionService).delete(100L, 1L);
+
+        mockMvc.perform(delete(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/solutions/{id} missing returns NOT_FOUND")
+    void deleteSolutionNotFound() throws Exception {
+        doThrow(new EntityNotFoundException("Solution not found: 100"))
+                .when(solutionService).delete(100L, 1L);
+
+        mockMvc.perform(delete(BASE_URL + "/100")
                         .header(MEMBER_ID_HEADER, "1"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))


### PR DESCRIPTION
## 🔗 관련 이슈 (Issue)
Closes #18

## ✅ 주요 작업 내용 (Changes)
- [x] `PUT /api/v1/solutions/{id}` 엔드포인트 추가
- [x] `DELETE /api/v1/solutions/{id}` 엔드포인트 추가
- [x] `X-Member-Id` 기반 소유자 검증 흐름을 그대로 사용하도록 연결
- [x] Swagger 설명을 수정/삭제 API까지 확장
- [x] `FORBIDDEN`, `NOT_FOUND` 응답을 포함한 WebMvc 테스트 추가

## 📸 스크린샷 (Optional)
- 없음

## ✅ 셀프 체크리스트 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그와 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 🔎 리뷰 포인트 (Review Point)
- 수정/삭제 API 응답 형식을 기존 `ApiResponse` 규약 안에서 유지한 방식이 적절한지 확인 부탁드립니다.
- 소유자 검증 실패와 미존재 리소스 응답이 컨트롤러 레벨에서 충분히 보호되는지 확인 부탁드립니다.
