### PR TITLE
[TEST] Solution/Problem 통합 테스트 및 WebMvc 테스트 안정화

### DIFF
--- a/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
@@ -237,6 +237,27 @@ class SolutionControllerTest {
     }
 
     @Test
+    @DisplayName("PUT /api/v1/solutions/{id} validation failure returns INVALID_INPUT")
+    void updateSolutionValidationFailure() throws Exception {
+        String invalidBody = """
+                {
+                  "code": "",
+                  "timeElapsed": -1,
+                  "solved": null,
+                  "memoMarkdown": ""
+                }
+                """;
+
+        mockMvc.perform(put(BASE_URL + "/100")
+                        .header(MEMBER_ID_HEADER, "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
     @DisplayName("DELETE /api/v1/solutions/{id} returns SUCCESS")
     void deleteSolution() throws Exception {
         mockMvc.perform(delete(BASE_URL + "/100")
@@ -280,6 +301,26 @@ class SolutionControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.code").value("MISSING_PARAMETER"));
+    }
+
+    @Test
+    @DisplayName("invalid path variable returns TYPE_MISMATCH")
+    void invalidPathVariableType() throws Exception {
+        mockMvc.perform(get(BASE_URL + "/abc")
+                        .header(MEMBER_ID_HEADER, "1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("TYPE_MISMATCH"));
+    }
+
+    @Test
+    @DisplayName("invalid X-Member-Id header type returns TYPE_MISMATCH")
+    void invalidMemberIdHeaderType() throws Exception {
+        mockMvc.perform(get(BASE_URL)
+                        .header(MEMBER_ID_HEADER, "abc"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("TYPE_MISMATCH"));
     }
 
     private SolutionResponse solutionResponse(Long id, Long memberId, Long problemId) {

--- a/src/test/java/org/sani/algolog/domain/solution/repository/SolutionRepositoryTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/repository/SolutionRepositoryTest.java
@@ -70,8 +70,8 @@ class SolutionRepositoryTest {
     }
 
     @Test
-    @DisplayName("회원 ID로 풀이 목록 조회 성공")
-    void findAllByMemberId() {
+    @DisplayName("회원 ID로 풀이 목록을 최신순으로 조회하면서 문제 연관관계를 함께 가져온다")
+    void findAllByMemberIdOrderByCreatedAtDesc() {
         // given
         Member member = memberRepository.save(Member.builder()
                 .email("list@test.com")
@@ -87,7 +87,15 @@ class SolutionRepositoryTest {
                 .difficulty("Bronze V")
                 .build());
 
-        solutionRepository.save(Solution.builder()
+        Problem newerProblem = problemRepository.save(Problem.builder()
+                .platform(Platform.BOJ)
+                .externalProblemId("1002")
+                .title("A/B")
+                .problemUrl("https://www.acmicpc.net/problem/1002")
+                .difficulty("Bronze IV")
+                .build());
+
+        Solution firstSolution = solutionRepository.save(Solution.builder()
                 .code("class Solution { }")
                 .timeElapsed(300)
                 .isSolved(true)
@@ -96,11 +104,57 @@ class SolutionRepositoryTest {
                 .member(member)
                 .build());
 
+        Solution secondSolution = solutionRepository.save(Solution.builder()
+                .code("class AnotherSolution { }")
+                .timeElapsed(150)
+                .isSolved(true)
+                .memoMarkdown("사칙연산 풀이")
+                .problem(newerProblem)
+                .member(member)
+                .build());
+
         // when
-        List<Solution> solutions = solutionRepository.findAllByMemberId(member.getId());
+        List<Solution> solutions = solutionRepository.findAllByMemberIdOrderByCreatedAtDesc(member.getId());
 
         // then
-        assertThat(solutions).hasSize(1);
-        assertThat(solutions.get(0).getProblem().getExternalProblemId()).isEqualTo("1001");
+        assertThat(solutions).hasSize(2);
+        assertThat(solutions.get(0).getId()).isEqualTo(secondSolution.getId());
+        assertThat(solutions.get(1).getId()).isEqualTo(firstSolution.getId());
+        assertThat(solutions.get(0).getProblem().getExternalProblemId()).isEqualTo("1002");
+        assertThat(solutions.get(1).getProblem().getExternalProblemId()).isEqualTo("1001");
+    }
+
+    @Test
+    @DisplayName("풀이 ID와 회원 ID로 상세 조회하면서 문제 연관관계를 함께 가져온다")
+    void findByIdAndMemberId() {
+        Member member = memberRepository.save(Member.builder()
+                .email("detail@test.com")
+                .nickname("상세조회")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build());
+        Problem problem = problemRepository.save(Problem.builder()
+                .platform(Platform.BOJ)
+                .externalProblemId("2557")
+                .title("Hello World")
+                .problemUrl("https://www.acmicpc.net/problem/2557")
+                .difficulty("Bronze V")
+                .build());
+
+        Solution solution = solutionRepository.save(Solution.builder()
+                .code("public class Main {}")
+                .timeElapsed(10)
+                .isSolved(true)
+                .memoMarkdown("기본 출력 문제")
+                .problem(problem)
+                .member(member)
+                .build());
+
+        Solution found = solutionRepository.findByIdAndMemberId(solution.getId(), member.getId())
+                .orElseThrow(() -> new IllegalArgumentException("풀이가 없습니다."));
+
+        assertThat(found.getId()).isEqualTo(solution.getId());
+        assertThat(found.getProblem().getTitle()).isEqualTo("Hello World");
+        assertThat(found.getProblem().getExternalProblemId()).isEqualTo("2557");
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Issue)
Closes #20

## ✅ 주요 작업 내용 (Changes)
- [x] `SolutionControllerTest`에 수정 요청 validation 실패 케이스 추가
- [x] path variable / `X-Member-Id` header type mismatch 응답 테스트 추가
- [x] `SolutionRepositoryTest`를 실제 사용 중인 조회 메서드 기준으로 보강
- [x] `findAllByMemberIdOrderByCreatedAtDesc`, `findByIdAndMemberId`에서 `Problem` 연관관계 조회 검증 추가
- [x] 전체 `./gradlew cleanTest test --no-daemon` 실행 및 XML/HTML 리포트 생성 확인

## 📸 스크린샷 (Optional)
- 없음

## ✅ 셀프 체크리스트 (Self Checklist)
- [x] 로컬 환경에서 전체 테스트를 실행하고 종료를 확인했나요?
- [x] 주요 테스트 결과 XML 파일이 0바이트가 아닌 상태로 생성되는지 확인했나요?
- [x] 새 API/예외 응답 케이스가 테스트로 보호되나요?

## 🔎 리뷰 포인트 (Review Point)
- `SolutionRepositoryTest`가 실제 서비스가 사용하는 fetch join 경로를 충분히 검증하는지 확인 부탁드립니다.
- 이번 범위에서 전체 테스트 안정화의 원인을 "단일 실행 기준 정상, 동시 실행 시 결과 파일 write 충돌 가능"으로 보는 판단이 적절한지 확인 부탁드립니다.
