### PR TITLE
[CHORE] 임시 인증 방식 정리 및 OAuth/JWT 전환 준비

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@
     - `QueryService`(MyBatis)가 대시보드용 통계 데이터 조회.
 3. **Database:** `Member` - `Solution` - `Problem` 구조로 정규화된 설계.
 
+### 현재 인증 처리 방식
+
+- 현재 MVP API는 임시로 `X-Member-Id` 헤더를 사용해 사용자를 식별합니다.
+- 컨트롤러는 헤더를 직접 받지 않고 `@CurrentMemberId`를 통해 현재 사용자 ID를 주입받습니다.
+- 이후 JWT 또는 OAuth Principal 기반 인증을 도입할 때는 컨트롤러 시그니처를 바꾸지 않고 argument resolver 구현만 교체하는 것을 목표로 합니다.
+
 ---
 
 ## 5. 데이터베이스 설계 (ERD)

--- a/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
+++ b/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
@@ -9,13 +9,13 @@ import org.sani.algolog.domain.solution.dto.SolutionResponse;
 import org.sani.algolog.domain.solution.dto.SolutionUpdateRequest;
 import org.sani.algolog.domain.solution.service.SolutionService;
 import org.sani.algolog.global.common.ApiResponse;
+import org.sani.algolog.security.resolver.CurrentMemberId;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,23 +27,27 @@ import java.util.List;
 @RequestMapping("/api/v1/solutions")
 public class SolutionController {
 
-    private static final String MEMBER_ID_HEADER = "X-Member-Id";
-
     private final SolutionService solutionService;
 
-    @Operation(summary = "Save solution", description = "Saves a solution for the member in X-Member-Id header.")
+    @Operation(
+            summary = "Save solution",
+            description = "Saves a solution for the current member resolved from the temporary X-Member-Id header."
+    )
     @PostMapping
     public ApiResponse<SolutionResponse> save(
-            @RequestHeader(MEMBER_ID_HEADER) Long memberId,
+            @CurrentMemberId Long memberId,
             @Valid @RequestBody SolutionCreateRequest request
     ) {
         return ApiResponse.success(solutionService.save(request, memberId));
     }
 
-    @Operation(summary = "Get my solutions", description = "Returns all solutions owned by the member in latest-first order.")
+    @Operation(
+            summary = "Get my solutions",
+            description = "Returns all solutions owned by the current member resolved from the temporary X-Member-Id header."
+    )
     @GetMapping
     public ApiResponse<List<SolutionResponse>> getSolutions(
-            @RequestHeader(MEMBER_ID_HEADER) Long memberId
+            @CurrentMemberId Long memberId
     ) {
         return ApiResponse.success(solutionService.getSolutionsByMember(memberId));
     }
@@ -52,26 +56,32 @@ public class SolutionController {
     @GetMapping("/{id}")
     public ApiResponse<SolutionResponse> getSolution(
             @PathVariable Long id,
-            @RequestHeader(MEMBER_ID_HEADER) Long memberId
+            @CurrentMemberId Long memberId
     ) {
         return ApiResponse.success(solutionService.getSolution(id, memberId));
     }
 
-    @Operation(summary = "Update solution", description = "Updates a solution only when owned by the member in X-Member-Id header.")
+    @Operation(
+            summary = "Update solution",
+            description = "Updates a solution only when owned by the current member resolved from the temporary X-Member-Id header."
+    )
     @PutMapping("/{id}")
     public ApiResponse<SolutionResponse> update(
             @PathVariable Long id,
-            @RequestHeader(MEMBER_ID_HEADER) Long memberId,
+            @CurrentMemberId Long memberId,
             @Valid @RequestBody SolutionUpdateRequest request
     ) {
         return ApiResponse.success(solutionService.update(id, request, memberId));
     }
 
-    @Operation(summary = "Delete solution", description = "Deletes a solution only when owned by the member in X-Member-Id header.")
+    @Operation(
+            summary = "Delete solution",
+            description = "Deletes a solution only when owned by the current member resolved from the temporary X-Member-Id header."
+    )
     @DeleteMapping("/{id}")
     public ApiResponse<Void> delete(
             @PathVariable Long id,
-            @RequestHeader(MEMBER_ID_HEADER) Long memberId
+            @CurrentMemberId Long memberId
     ) {
         solutionService.delete(id, memberId);
         return ApiResponse.success();

--- a/src/main/java/org/sani/algolog/global/config/WebConfig.java
+++ b/src/main/java/org/sani/algolog/global/config/WebConfig.java
@@ -1,0 +1,17 @@
+package org.sani.algolog.global.config;
+
+import org.sani.algolog.security.resolver.CurrentMemberIdArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new CurrentMemberIdArgumentResolver());
+    }
+}

--- a/src/main/java/org/sani/algolog/security/resolver/CurrentMemberId.java
+++ b/src/main/java/org/sani/algolog/security/resolver/CurrentMemberId.java
@@ -1,0 +1,11 @@
+package org.sani.algolog.security.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentMemberId {
+}

--- a/src/main/java/org/sani/algolog/security/resolver/CurrentMemberIdArgumentResolver.java
+++ b/src/main/java/org/sani/algolog/security/resolver/CurrentMemberIdArgumentResolver.java
@@ -1,0 +1,50 @@
+package org.sani.algolog.security.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class CurrentMemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String MEMBER_ID_HEADER = "X-Member-Id";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentMemberId.class)
+                && (Long.class.equals(parameter.getParameterType()) || long.class.equals(parameter.getParameterType()));
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            org.springframework.web.bind.support.WebDataBinderFactory binderFactory
+    ) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (request == null) {
+            throw new IllegalStateException("HttpServletRequest is required.");
+        }
+
+        String memberIdHeader = request.getHeader(MEMBER_ID_HEADER);
+        if (memberIdHeader == null || memberIdHeader.isBlank()) {
+            throw new ServletRequestBindingException("Missing request header '" + MEMBER_ID_HEADER + "'");
+        }
+
+        try {
+            return Long.valueOf(memberIdHeader);
+        } catch (NumberFormatException exception) {
+            throw new MethodArgumentTypeMismatchException(
+                    memberIdHeader,
+                    Long.class,
+                    MEMBER_ID_HEADER,
+                    parameter,
+                    exception
+            );
+        }
+    }
+}

--- a/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
@@ -7,6 +7,7 @@ import org.sani.algolog.domain.problem.dto.ProblemResponse;
 import org.sani.algolog.domain.problem.entity.Platform;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
 import org.sani.algolog.domain.solution.service.SolutionService;
+import org.sani.algolog.global.config.WebConfig;
 import org.sani.algolog.global.error.GlobalExceptionHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -32,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = SolutionController.class)
-@Import(GlobalExceptionHandler.class)
+@Import({GlobalExceptionHandler.class, WebConfig.class})
 @AutoConfigureMockMvc(addFilters = false)
 class SolutionControllerTest {
 


### PR DESCRIPTION
## 🔗 관련 이슈 (Issue)
Closes #21

## ✅ 주요 작업 내용 (Changes)
- [x] `@CurrentMemberId` 애노테이션 추가
- [x] `CurrentMemberIdArgumentResolver`로 임시 `X-Member-Id` 헤더 해석 로직 공통화
- [x] `WebConfig`에 argument resolver 등록
- [x] `SolutionController`에서 `@RequestHeader("X-Member-Id")` 직접 의존 제거
- [x] README에 현재 임시 인증 방식과 향후 resolver 교체 방향 명시
- [x] WebMvc 테스트가 기존 오류 코드(`MISSING_PARAMETER`, `TYPE_MISMATCH`)를 유지하는지 확인

## 📸 스크린샷 (Optional)
- 없음

## ✅ 셀프 체크리스트 (Self Checklist)
- [x] 컨트롤러 시그니처가 임시 인증 헤더 구현에 직접 묶여 있지 않나요?
- [x] 현재 요청 규약(`X-Member-Id`)은 그대로 유지되나요?
- [x] 나중에 JWT/Principal 기반으로 바꿀 때 resolver 교체만으로 전환 가능한 구조인가요?
- [x] 로컬에서 관련 테스트를 실행했나요?

## 🔎 리뷰 포인트 (Review Point)
- `CurrentMemberIdArgumentResolver`를 현재 전환 포인트로 두는 구조가 적절한지 확인 부탁드립니다.
- 추후 SecurityContext 기반 principal 해석으로 옮길 때 현재 패키지/구성 위치가 자연스러운지 확인 부탁드립니다.
