### PR TITLE
[FEAT] GitHub OAuth 로그인 기반 인증 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Local runtime secrets
+src/main/resources/application-local.properties

--- a/README.md
+++ b/README.md
@@ -93,9 +93,17 @@
 
 ### 현재 인증 처리 방식
 
-- 현재 MVP API는 임시로 `X-Member-Id` 헤더를 사용해 사용자를 식별합니다.
-- 컨트롤러는 헤더를 직접 받지 않고 `@CurrentMemberId`를 통해 현재 사용자 ID를 주입받습니다.
-- 이후 JWT 또는 OAuth Principal 기반 인증을 도입할 때는 컨트롤러 시그니처를 바꾸지 않고 argument resolver 구현만 교체하는 것을 목표로 합니다.
+- 현재 MVP API는 GitHub OAuth 2.0 로그인 후 세션 기반으로 사용자를 식별합니다.
+- 컨트롤러는 인증 구현 상세를 직접 다루지 않고 `@CurrentMemberId`를 통해 현재 사용자 ID를 주입받습니다.
+- 이후 JWT 기반 인증으로 전환하더라도 컨트롤러 시그니처를 바꾸지 않고 argument resolver 또는 인증 계층만 교체하는 것을 목표로 합니다.
+
+### GitHub OAuth 로컬 설정
+
+- 환경 변수
+  - `GITHUB_CLIENT_ID`
+  - `GITHUB_CLIENT_SECRET`
+- 필요 scope: `read:user`, `user:email`
+- 로그인 진입 경로: `/oauth2/authorization/github`
 
 ---
 

--- a/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
+++ b/src/main/java/org/sani/algolog/domain/solution/controller/SolutionController.java
@@ -31,7 +31,7 @@ public class SolutionController {
 
     @Operation(
             summary = "Save solution",
-            description = "Saves a solution for the current member resolved from the temporary X-Member-Id header."
+            description = "Saves a solution for the currently authenticated member."
     )
     @PostMapping
     public ApiResponse<SolutionResponse> save(
@@ -43,7 +43,7 @@ public class SolutionController {
 
     @Operation(
             summary = "Get my solutions",
-            description = "Returns all solutions owned by the current member resolved from the temporary X-Member-Id header."
+            description = "Returns all solutions owned by the currently authenticated member."
     )
     @GetMapping
     public ApiResponse<List<SolutionResponse>> getSolutions(
@@ -63,7 +63,7 @@ public class SolutionController {
 
     @Operation(
             summary = "Update solution",
-            description = "Updates a solution only when owned by the current member resolved from the temporary X-Member-Id header."
+            description = "Updates a solution only when owned by the currently authenticated member."
     )
     @PutMapping("/{id}")
     public ApiResponse<SolutionResponse> update(
@@ -76,7 +76,7 @@ public class SolutionController {
 
     @Operation(
             summary = "Delete solution",
-            description = "Deletes a solution only when owned by the current member resolved from the temporary X-Member-Id header."
+            description = "Deletes a solution only when owned by the currently authenticated member."
     )
     @DeleteMapping("/{id}")
     public ApiResponse<Void> delete(

--- a/src/main/java/org/sani/algolog/global/config/SecurityConfig.java
+++ b/src/main/java/org/sani/algolog/global/config/SecurityConfig.java
@@ -1,0 +1,66 @@
+package org.sani.algolog.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.security.handler.ApiAccessDeniedHandler;
+import org.sani.algolog.security.handler.ApiAuthenticationEntryPoint;
+import org.sani.algolog.security.oauth.CustomOAuth2UserService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final ApiAuthenticationEntryPoint apiAuthenticationEntryPoint;
+    private final ApiAccessDeniedHandler apiAccessDeniedHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http,
+            ObjectProvider<ClientRegistrationRepository> clientRegistrationRepositoryProvider
+    ) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(logout -> logout.logoutSuccessUrl("/"))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(
+                                "/",
+                                "/error",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/login/**",
+                                "/oauth2/**"
+                        ).permitAll()
+                        .requestMatchers("/api/**").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .defaultAuthenticationEntryPointFor(
+                                apiAuthenticationEntryPoint,
+                                new AntPathRequestMatcher("/api/**")
+                        )
+                        .defaultAccessDeniedHandlerFor(
+                                apiAccessDeniedHandler,
+                                new AntPathRequestMatcher("/api/**")
+                        )
+                );
+
+        if (clientRegistrationRepositoryProvider.getIfAvailable() != null) {
+            http.oauth2Login(oauth2 -> oauth2
+                    .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                    .loginPage("/oauth2/authorization/github")
+            );
+        }
+
+        return http.build();
+    }
+}

--- a/src/main/java/org/sani/algolog/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sani/algolog/global/config/SwaggerConfig.java
@@ -11,23 +11,27 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-    private static final String MEMBER_ID_SCHEME = "memberIdHeader";
-    private static final String MEMBER_ID_HEADER = "X-Member-Id";
+    private static final String GITHUB_OAUTH_SCHEME = "githubOAuth";
 
     @Bean
     public OpenAPI openAPI() {
-        SecurityScheme memberIdScheme = new SecurityScheme()
-                .type(SecurityScheme.Type.APIKEY)
-                .in(SecurityScheme.In.HEADER)
-                .name(MEMBER_ID_HEADER)
-                .description("Temporary member identification header for MVP APIs.");
+        SecurityScheme githubOAuthScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.OAUTH2)
+                .description("GitHub OAuth2 login for authenticated AlgoLog APIs.")
+                .flows(new io.swagger.v3.oas.models.security.OAuthFlows()
+                        .authorizationCode(new io.swagger.v3.oas.models.security.OAuthFlow()
+                                .authorizationUrl("https://github.com/login/oauth/authorize")
+                                .tokenUrl("https://github.com/login/oauth/access_token")
+                                .scopes(new io.swagger.v3.oas.models.security.Scopes()
+                                        .addString("read:user", "Read GitHub profile")
+                                        .addString("user:email", "Read GitHub email"))));
 
         return new OpenAPI()
                 .info(new Info()
                         .title("AlgoLog API")
                         .version("v1")
                         .description("AlgoLog REST API documentation"))
-                .components(new Components().addSecuritySchemes(MEMBER_ID_SCHEME, memberIdScheme))
-                .addSecurityItem(new SecurityRequirement().addList(MEMBER_ID_SCHEME));
+                .components(new Components().addSecuritySchemes(GITHUB_OAUTH_SCHEME, githubOAuthScheme))
+                .addSecurityItem(new SecurityRequirement().addList(GITHUB_OAUTH_SCHEME));
     }
 }

--- a/src/main/java/org/sani/algolog/security/handler/ApiAccessDeniedHandler.java
+++ b/src/main/java/org/sani/algolog/security/handler/ApiAccessDeniedHandler.java
@@ -1,24 +1,20 @@
 package org.sani.algolog.security.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.sani.algolog.global.common.ApiResponse;
 import org.sani.algolog.global.error.ErrorCode;
-import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
 public class ApiAccessDeniedHandler implements AccessDeniedHandler {
 
-    private final ObjectMapper objectMapper;
+    private final SecurityErrorResponseWriter securityErrorResponseWriter;
 
     @Override
     public void handle(
@@ -26,13 +22,6 @@ public class ApiAccessDeniedHandler implements AccessDeniedHandler {
             HttpServletResponse response,
             AccessDeniedException accessDeniedException
     ) throws IOException {
-        writeErrorResponse(response, ErrorCode.FORBIDDEN, ErrorCode.FORBIDDEN.getMessage());
-    }
-
-    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode, String message) throws IOException {
-        response.setStatus(errorCode.getStatus());
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        objectMapper.writeValue(response.getWriter(), ApiResponse.fail(errorCode, message));
+        securityErrorResponseWriter.write(response, ErrorCode.FORBIDDEN, ErrorCode.FORBIDDEN.getMessage());
     }
 }

--- a/src/main/java/org/sani/algolog/security/handler/ApiAccessDeniedHandler.java
+++ b/src/main/java/org/sani/algolog/security/handler/ApiAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package org.sani.algolog.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.global.common.ApiResponse;
+import org.sani.algolog.global.error.ErrorCode;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class ApiAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        writeErrorResponse(response, ErrorCode.FORBIDDEN, ErrorCode.FORBIDDEN.getMessage());
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode, String message) throws IOException {
+        response.setStatus(errorCode.getStatus());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), ApiResponse.fail(errorCode, message));
+    }
+}

--- a/src/main/java/org/sani/algolog/security/handler/ApiAuthenticationEntryPoint.java
+++ b/src/main/java/org/sani/algolog/security/handler/ApiAuthenticationEntryPoint.java
@@ -1,24 +1,20 @@
 package org.sani.algolog.security.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.sani.algolog.global.common.ApiResponse;
 import org.sani.algolog.global.error.ErrorCode;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
 public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private final ObjectMapper objectMapper;
+    private final SecurityErrorResponseWriter securityErrorResponseWriter;
 
     @Override
     public void commence(
@@ -26,13 +22,6 @@ public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
             HttpServletResponse response,
             AuthenticationException authException
     ) throws IOException {
-        writeErrorResponse(response, ErrorCode.UNAUTHORIZED, ErrorCode.UNAUTHORIZED.getMessage());
-    }
-
-    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode, String message) throws IOException {
-        response.setStatus(errorCode.getStatus());
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        objectMapper.writeValue(response.getWriter(), ApiResponse.fail(errorCode, message));
+        securityErrorResponseWriter.write(response, ErrorCode.UNAUTHORIZED, ErrorCode.UNAUTHORIZED.getMessage());
     }
 }

--- a/src/main/java/org/sani/algolog/security/handler/ApiAuthenticationEntryPoint.java
+++ b/src/main/java/org/sani/algolog/security/handler/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package org.sani.algolog.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.global.common.ApiResponse;
+import org.sani.algolog.global.error.ErrorCode;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        writeErrorResponse(response, ErrorCode.UNAUTHORIZED, ErrorCode.UNAUTHORIZED.getMessage());
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode, String message) throws IOException {
+        response.setStatus(errorCode.getStatus());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), ApiResponse.fail(errorCode, message));
+    }
+}

--- a/src/main/java/org/sani/algolog/security/handler/SecurityErrorResponseWriter.java
+++ b/src/main/java/org/sani/algolog/security/handler/SecurityErrorResponseWriter.java
@@ -1,0 +1,26 @@
+package org.sani.algolog.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.global.common.ApiResponse;
+import org.sani.algolog.global.error.ErrorCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityErrorResponseWriter {
+
+    private final ObjectMapper objectMapper;
+
+    public void write(HttpServletResponse response, ErrorCode errorCode, String message) throws IOException {
+        response.setStatus(errorCode.getStatus());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), ApiResponse.fail(errorCode, message));
+    }
+}

--- a/src/main/java/org/sani/algolog/security/oauth/AlgoLogAuthenticatedPrincipal.java
+++ b/src/main/java/org/sani/algolog/security/oauth/AlgoLogAuthenticatedPrincipal.java
@@ -1,0 +1,6 @@
+package org.sani.algolog.security.oauth;
+
+public interface AlgoLogAuthenticatedPrincipal {
+
+    Long getMemberId();
+}

--- a/src/main/java/org/sani/algolog/security/oauth/AlgoLogOAuth2User.java
+++ b/src/main/java/org/sani/algolog/security/oauth/AlgoLogOAuth2User.java
@@ -1,0 +1,62 @@
+package org.sani.algolog.security.oauth;
+
+import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.member.entity.Role;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class AlgoLogOAuth2User implements OAuth2User, AlgoLogAuthenticatedPrincipal {
+
+    private final Long memberId;
+    private final String email;
+    private final String nickname;
+    private final Role role;
+    private final Map<String, Object> attributes;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public AlgoLogOAuth2User(Member member, Map<String, Object> attributes) {
+        this.memberId = member.getId();
+        this.email = member.getEmail();
+        this.nickname = member.getNickname();
+        this.role = member.getRole();
+        this.attributes = attributes;
+        this.authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(memberId);
+    }
+}

--- a/src/main/java/org/sani/algolog/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/org/sani/algolog/security/oauth/CustomOAuth2UserService.java
@@ -16,8 +16,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        OAuth2User oauth2User = super.loadUser(userRequest);
         validateGithubRegistration(userRequest);
+        OAuth2User oauth2User = super.loadUser(userRequest);
 
         GithubOAuthUserInfo userInfo = GithubOAuthUserInfo.from(oauth2User.getAttributes());
         Member member = oauthMemberService.getOrCreateGithubMember(userInfo);

--- a/src/main/java/org/sani/algolog/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/org/sani/algolog/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,33 @@
+package org.sani.algolog.security.oauth;
+
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.domain.member.entity.Member;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final OAuthMemberService oauthMemberService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oauth2User = super.loadUser(userRequest);
+        validateGithubRegistration(userRequest);
+
+        GithubOAuthUserInfo userInfo = GithubOAuthUserInfo.from(oauth2User.getAttributes());
+        Member member = oauthMemberService.getOrCreateGithubMember(userInfo);
+        return new AlgoLogOAuth2User(member, oauth2User.getAttributes());
+    }
+
+    private void validateGithubRegistration(OAuth2UserRequest userRequest) {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        if (!"github".equals(registrationId)) {
+            throw new OAuth2AuthenticationException("Unsupported OAuth registration: " + registrationId);
+        }
+    }
+}

--- a/src/main/java/org/sani/algolog/security/oauth/GithubOAuthUserInfo.java
+++ b/src/main/java/org/sani/algolog/security/oauth/GithubOAuthUserInfo.java
@@ -32,9 +32,6 @@ public record GithubOAuthUserInfo(
     }
 
     public String nicknameCandidate() {
-        if (name != null && !name.isBlank()) {
-            return name;
-        }
         return login;
     }
 

--- a/src/main/java/org/sani/algolog/security/oauth/GithubOAuthUserInfo.java
+++ b/src/main/java/org/sani/algolog/security/oauth/GithubOAuthUserInfo.java
@@ -23,7 +23,7 @@ public record GithubOAuthUserInfo(
             throw invalidUserInfo("GitHub login is missing.");
         }
 
-        String normalizedName = nameValue instanceof String stringName ? stringName : null;
+        String normalizedName = nameValue instanceof String stringName ? stringName.trim() : null;
         return new GithubOAuthUserInfo(idNumber.longValue(), login.trim(), normalizedName);
     }
 
@@ -33,7 +33,7 @@ public record GithubOAuthUserInfo(
 
     public String nicknameCandidate() {
         if (name != null && !name.isBlank()) {
-            return name.trim();
+            return name;
         }
         return login;
     }

--- a/src/main/java/org/sani/algolog/security/oauth/GithubOAuthUserInfo.java
+++ b/src/main/java/org/sani/algolog/security/oauth/GithubOAuthUserInfo.java
@@ -1,0 +1,44 @@
+package org.sani.algolog.security.oauth;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+import java.util.Map;
+
+public record GithubOAuthUserInfo(
+        Long githubId,
+        String login,
+        String name
+) {
+
+    public static GithubOAuthUserInfo from(Map<String, Object> attributes) {
+        Object idValue = attributes.get("id");
+        Object loginValue = attributes.get("login");
+        Object nameValue = attributes.get("name");
+
+        if (!(idValue instanceof Number idNumber)) {
+            throw invalidUserInfo("GitHub user id is missing.");
+        }
+        if (!(loginValue instanceof String login) || login.isBlank()) {
+            throw invalidUserInfo("GitHub login is missing.");
+        }
+
+        String normalizedName = nameValue instanceof String stringName ? stringName : null;
+        return new GithubOAuthUserInfo(idNumber.longValue(), login.trim(), normalizedName);
+    }
+
+    public String canonicalEmail() {
+        return "github-" + githubId + "@users.noreply.github.com";
+    }
+
+    public String nicknameCandidate() {
+        if (name != null && !name.isBlank()) {
+            return name.trim();
+        }
+        return login;
+    }
+
+    private static OAuth2AuthenticationException invalidUserInfo(String message) {
+        return new OAuth2AuthenticationException(new OAuth2Error("invalid_user_info"), message);
+    }
+}

--- a/src/main/java/org/sani/algolog/security/oauth/OAuthMemberService.java
+++ b/src/main/java/org/sani/algolog/security/oauth/OAuthMemberService.java
@@ -1,0 +1,75 @@
+package org.sani.algolog.security.oauth;
+
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.member.entity.Provider;
+import org.sani.algolog.domain.member.entity.Role;
+import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.global.error.exception.ConflictException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OAuthMemberService {
+
+    private static final int MAX_NICKNAME_LENGTH = 20;
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member getOrCreateGithubMember(GithubOAuthUserInfo userInfo) {
+        return memberRepository.findByEmail(userInfo.canonicalEmail())
+                .map(this::validateGithubMember)
+                .orElseGet(() -> createGithubMember(userInfo));
+    }
+
+    private Member validateGithubMember(Member member) {
+        if (member.getProvider() != Provider.GITHUB) {
+            throw new ConflictException("이미 다른 로그인 방식으로 가입된 사용자입니다.");
+        }
+        return member;
+    }
+
+    private Member createGithubMember(GithubOAuthUserInfo userInfo) {
+        String nickname = generateUniqueNickname(userInfo.nicknameCandidate(), userInfo.githubId());
+        Member member = Member.builder()
+                .email(userInfo.canonicalEmail())
+                .nickname(nickname)
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+
+        return memberRepository.save(member);
+    }
+
+    private String generateUniqueNickname(String rawNickname, Long githubId) {
+        String baseNickname = normalizeNickname(rawNickname, githubId);
+        String candidate = truncate(baseNickname, MAX_NICKNAME_LENGTH);
+        int suffix = 1;
+
+        while (memberRepository.findByNickname(candidate).isPresent()) {
+            String suffixText = String.valueOf(suffix++);
+            String truncatedBase = truncate(baseNickname, MAX_NICKNAME_LENGTH - suffixText.length());
+            candidate = truncatedBase + suffixText;
+        }
+
+        return candidate;
+    }
+
+    private String normalizeNickname(String rawNickname, Long githubId) {
+        String normalized = rawNickname == null ? "" : rawNickname.trim().replaceAll("\\s+", "-");
+        if (normalized.length() >= 2) {
+            return normalized;
+        }
+        return "gh" + githubId;
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+}

--- a/src/main/java/org/sani/algolog/security/oauth/OAuthMemberService.java
+++ b/src/main/java/org/sani/algolog/security/oauth/OAuthMemberService.java
@@ -6,6 +6,7 @@ import org.sani.algolog.domain.member.entity.Provider;
 import org.sani.algolog.domain.member.entity.Role;
 import org.sani.algolog.domain.member.repository.MemberRepository;
 import org.sani.algolog.global.error.exception.ConflictException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OAuthMemberService {
 
     private static final int MAX_NICKNAME_LENGTH = 20;
+    private static final int MAX_NICKNAME_RETRY_COUNT = 5;
 
     private final MemberRepository memberRepository;
 
@@ -33,29 +35,48 @@ public class OAuthMemberService {
     }
 
     private Member createGithubMember(GithubOAuthUserInfo userInfo) {
-        String nickname = generateUniqueNickname(userInfo.nicknameCandidate(), userInfo.githubId());
-        Member member = Member.builder()
+        String baseNickname = normalizeNickname(userInfo.nicknameCandidate(), userInfo.githubId());
+        DataIntegrityViolationException lastException = null;
+
+        for (int attempt = 0; attempt < MAX_NICKNAME_RETRY_COUNT; attempt++) {
+            String nickname = generateNicknameCandidate(baseNickname, attempt);
+            if (memberRepository.findByNickname(nickname).isPresent()) {
+                continue;
+            }
+
+            try {
+                return memberRepository.save(buildGithubMember(userInfo, nickname));
+            } catch (DataIntegrityViolationException exception) {
+                Member existingMember = memberRepository.findByEmail(userInfo.canonicalEmail())
+                        .map(this::validateGithubMember)
+                        .orElse(null);
+                if (existingMember != null) {
+                    return existingMember;
+                }
+                lastException = exception;
+            }
+        }
+
+        throw newConflict("GitHub 닉네임을 생성하는 중 충돌이 반복되었습니다.", lastException);
+    }
+
+    private Member buildGithubMember(GithubOAuthUserInfo userInfo, String nickname) {
+        return Member.builder()
                 .email(userInfo.canonicalEmail())
                 .nickname(nickname)
                 .provider(Provider.GITHUB)
                 .role(Role.USER)
                 .build();
-
-        return memberRepository.save(member);
     }
 
-    private String generateUniqueNickname(String rawNickname, Long githubId) {
-        String baseNickname = normalizeNickname(rawNickname, githubId);
-        String candidate = truncate(baseNickname, MAX_NICKNAME_LENGTH);
-        int suffix = 1;
-
-        while (memberRepository.findByNickname(candidate).isPresent()) {
-            String suffixText = String.valueOf(suffix++);
-            String truncatedBase = truncate(baseNickname, MAX_NICKNAME_LENGTH - suffixText.length());
-            candidate = truncatedBase + suffixText;
+    private String generateNicknameCandidate(String baseNickname, int attempt) {
+        if (attempt == 0) {
+            return truncate(baseNickname, MAX_NICKNAME_LENGTH);
         }
 
-        return candidate;
+        String suffixText = String.valueOf(attempt);
+        String truncatedBase = truncate(baseNickname, MAX_NICKNAME_LENGTH - suffixText.length());
+        return truncatedBase + suffixText;
     }
 
     private String normalizeNickname(String rawNickname, Long githubId) {
@@ -71,5 +92,11 @@ public class OAuthMemberService {
             return value;
         }
         return value.substring(0, maxLength);
+    }
+
+    private ConflictException newConflict(String message, Throwable cause) {
+        ConflictException exception = new ConflictException(message);
+        exception.initCause(cause);
+        return exception;
     }
 }

--- a/src/main/java/org/sani/algolog/security/resolver/CurrentMemberIdArgumentResolver.java
+++ b/src/main/java/org/sani/algolog/security/resolver/CurrentMemberIdArgumentResolver.java
@@ -1,16 +1,19 @@
 package org.sani.algolog.security.resolver;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.sani.algolog.global.error.exception.UnauthorizedException;
+import org.sani.algolog.security.oauth.AlgoLogAuthenticatedPrincipal;
 import org.springframework.core.MethodParameter;
-import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 public class CurrentMemberIdArgumentResolver implements HandlerMethodArgumentResolver {
-
-    private static final String MEMBER_ID_HEADER = "X-Member-Id";
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -25,26 +28,45 @@ public class CurrentMemberIdArgumentResolver implements HandlerMethodArgumentRes
             NativeWebRequest webRequest,
             org.springframework.web.bind.support.WebDataBinderFactory binderFactory
     ) throws Exception {
+        Authentication authentication = resolveAuthentication(webRequest);
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnauthorizedException("인증된 사용자 정보가 없습니다.");
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof AlgoLogAuthenticatedPrincipal authenticatedPrincipal)) {
+            throw new UnauthorizedException("현재 사용자 정보를 확인할 수 없습니다.");
+        }
+
+        return authenticatedPrincipal.getMemberId();
+    }
+
+    private Authentication resolveAuthentication(NativeWebRequest webRequest) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            return authentication;
+        }
+
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         if (request == null) {
-            throw new IllegalStateException("HttpServletRequest is required.");
+            return null;
         }
 
-        String memberIdHeader = request.getHeader(MEMBER_ID_HEADER);
-        if (memberIdHeader == null || memberIdHeader.isBlank()) {
-            throw new ServletRequestBindingException("Missing request header '" + MEMBER_ID_HEADER + "'");
+        Object requestContext = request.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
+        if (requestContext instanceof SecurityContext securityContext && securityContext.getAuthentication() != null) {
+            return securityContext.getAuthentication();
         }
 
-        try {
-            return Long.valueOf(memberIdHeader);
-        } catch (NumberFormatException exception) {
-            throw new MethodArgumentTypeMismatchException(
-                    memberIdHeader,
-                    Long.class,
-                    MEMBER_ID_HEADER,
-                    parameter,
-                    exception
-            );
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return null;
         }
+
+        Object sessionContext = session.getAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
+        if (sessionContext instanceof SecurityContext securityContext) {
+            return securityContext.getAuthentication();
+        }
+
+        return null;
     }
 }

--- a/src/main/resources/application-local.properties.example
+++ b/src/main/resources/application-local.properties.example
@@ -1,0 +1,15 @@
+## Copy this file to application-local.properties and replace placeholder values.
+## Run with:
+## ./gradlew bootRun --args='--spring.profiles.active=local'
+
+spring.datasource.url=jdbc:mysql://localhost:3306/algolog?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=0000
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+
+spring.security.oauth2.client.registration.github.client-id=YOUR_GITHUB_CLIENT_ID
+spring.security.oauth2.client.registration.github.client-secret=YOUR_GITHUB_CLIENT_SECRET
+spring.security.oauth2.client.registration.github.scope=read:user,user:email

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,10 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+# Configure these environment variables to enable GitHub OAuth login.
+# GITHUB_CLIENT_ID=...
+# GITHUB_CLIENT_SECRET=...
+# spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
+# spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
+# spring.security.oauth2.client.registration.github.scope=read:user,user:email

--- a/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerSecurityIT.java
+++ b/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerSecurityIT.java
@@ -1,0 +1,32 @@
+package org.sani.algolog.domain.solution.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class SolutionControllerSecurityIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("missing authentication is handled by security entry point")
+    void missingAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/solutions"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+}

--- a/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
@@ -7,8 +7,11 @@ import org.sani.algolog.domain.problem.dto.ProblemResponse;
 import org.sani.algolog.domain.problem.entity.Platform;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
 import org.sani.algolog.domain.solution.service.SolutionService;
+import org.sani.algolog.global.error.exception.UnauthorizedException;
+import org.sani.algolog.security.oauth.AlgoLogAuthenticatedPrincipal;
 import org.sani.algolog.global.config.WebConfig;
 import org.sani.algolog.global.error.GlobalExceptionHandler;
+import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -29,6 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -38,7 +42,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class SolutionControllerTest {
 
     private static final String BASE_URL = "/api/v1/solutions";
-    private static final String MEMBER_ID_HEADER = "X-Member-Id";
 
     @Autowired
     private MockMvc mockMvc;
@@ -69,7 +72,7 @@ class SolutionControllerTest {
                 """;
 
         mockMvc.perform(post(BASE_URL)
-                        .header(MEMBER_ID_HEADER, "1")
+                        .with(authentication(authenticatedMember(1L)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isOk())
@@ -98,7 +101,7 @@ class SolutionControllerTest {
                 """;
 
         mockMvc.perform(post(BASE_URL)
-                        .header(MEMBER_ID_HEADER, "1")
+                        .with(authentication(authenticatedMember(1L)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidBody))
                 .andExpect(status().isBadRequest())
@@ -114,7 +117,7 @@ class SolutionControllerTest {
         when(solutionService.getSolutionsByMember(1L)).thenReturn(List.of(first, second));
 
         mockMvc.perform(get(BASE_URL)
-                        .header(MEMBER_ID_HEADER, "1"))
+                        .with(authentication(authenticatedMember(1L))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
@@ -129,7 +132,7 @@ class SolutionControllerTest {
         when(solutionService.getSolution(100L, 1L)).thenReturn(solutionResponse(100L, 1L, 10L));
 
         mockMvc.perform(get(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1"))
+                        .with(authentication(authenticatedMember(1L))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
@@ -144,7 +147,7 @@ class SolutionControllerTest {
                 .thenThrow(new AccessDeniedException("Access is denied."));
 
         mockMvc.perform(get(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1"))
+                        .with(authentication(authenticatedMember(1L))))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.status").value(403))
                 .andExpect(jsonPath("$.code").value("FORBIDDEN"));
@@ -157,7 +160,7 @@ class SolutionControllerTest {
                 .thenThrow(new EntityNotFoundException("Solution not found: 100"));
 
         mockMvc.perform(get(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1"))
+                        .with(authentication(authenticatedMember(1L))))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"));
@@ -179,7 +182,7 @@ class SolutionControllerTest {
                 """;
 
         mockMvc.perform(put(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1")
+                        .with(authentication(authenticatedMember(1L)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isOk())
@@ -205,7 +208,7 @@ class SolutionControllerTest {
                 """;
 
         mockMvc.perform(put(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1")
+                        .with(authentication(authenticatedMember(1L)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isForbidden())
@@ -229,7 +232,7 @@ class SolutionControllerTest {
                 """;
 
         mockMvc.perform(put(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1")
+                        .with(authentication(authenticatedMember(1L)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
                 .andExpect(status().isNotFound())
@@ -250,7 +253,7 @@ class SolutionControllerTest {
                 """;
 
         mockMvc.perform(put(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1")
+                        .with(authentication(authenticatedMember(1L)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidBody))
                 .andExpect(status().isBadRequest())
@@ -262,7 +265,7 @@ class SolutionControllerTest {
     @DisplayName("DELETE /api/v1/solutions/{id} returns SUCCESS")
     void deleteSolution() throws Exception {
         mockMvc.perform(delete(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1"))
+                        .with(authentication(authenticatedMember(1L))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
@@ -276,7 +279,7 @@ class SolutionControllerTest {
                 .when(solutionService).delete(100L, 1L);
 
         mockMvc.perform(delete(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1"))
+                        .with(authentication(authenticatedMember(1L))))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.status").value(403))
                 .andExpect(jsonPath("$.code").value("FORBIDDEN"));
@@ -289,39 +292,42 @@ class SolutionControllerTest {
                 .when(solutionService).delete(100L, 1L);
 
         mockMvc.perform(delete(BASE_URL + "/100")
-                        .header(MEMBER_ID_HEADER, "1"))
+                        .with(authentication(authenticatedMember(1L))))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"));
     }
 
     @Test
-    @DisplayName("missing X-Member-Id header returns MISSING_PARAMETER")
-    void missingMemberIdHeader() throws Exception {
+    @DisplayName("missing authentication returns UNAUTHORIZED")
+    void missingAuthentication() throws Exception {
         mockMvc.perform(get(BASE_URL))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.code").value("MISSING_PARAMETER"));
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
     }
 
     @Test
     @DisplayName("invalid path variable returns TYPE_MISMATCH")
     void invalidPathVariableType() throws Exception {
         mockMvc.perform(get(BASE_URL + "/abc")
-                        .header(MEMBER_ID_HEADER, "1"))
+                        .with(authentication(authenticatedMember(1L))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.code").value("TYPE_MISMATCH"));
     }
 
     @Test
-    @DisplayName("invalid X-Member-Id header type returns TYPE_MISMATCH")
-    void invalidMemberIdHeaderType() throws Exception {
+    @DisplayName("invalid authenticated principal returns UNAUTHORIZED")
+    void invalidAuthenticatedPrincipal() throws Exception {
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("anonymous", null);
+        authentication.setAuthenticated(true);
+
         mockMvc.perform(get(BASE_URL)
-                        .header(MEMBER_ID_HEADER, "abc"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.code").value("TYPE_MISMATCH"));
+                        .with(authentication(authentication)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
     }
 
     private SolutionResponse solutionResponse(Long id, Long memberId, Long problemId) {
@@ -344,5 +350,18 @@ class SolutionControllerTest {
                 .createdAt(now)
                 .updatedAt(now)
                 .build();
+    }
+
+    private TestingAuthenticationToken authenticatedMember(Long memberId) {
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(new TestPrincipal(memberId), null);
+        authentication.setAuthenticated(true);
+        return authentication;
+    }
+
+    private record TestPrincipal(Long memberId) implements AlgoLogAuthenticatedPrincipal {
+        @Override
+        public Long getMemberId() {
+            return memberId;
+        }
     }
 }

--- a/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
+++ b/src/test/java/org/sani/algolog/domain/solution/controller/SolutionControllerTest.java
@@ -7,10 +7,9 @@ import org.sani.algolog.domain.problem.dto.ProblemResponse;
 import org.sani.algolog.domain.problem.entity.Platform;
 import org.sani.algolog.domain.solution.dto.SolutionResponse;
 import org.sani.algolog.domain.solution.service.SolutionService;
-import org.sani.algolog.global.error.exception.UnauthorizedException;
-import org.sani.algolog.security.oauth.AlgoLogAuthenticatedPrincipal;
 import org.sani.algolog.global.config.WebConfig;
 import org.sani.algolog.global.error.GlobalExceptionHandler;
+import org.sani.algolog.security.oauth.AlgoLogAuthenticatedPrincipal;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -304,7 +303,8 @@ class SolutionControllerTest {
         mockMvc.perform(get(BASE_URL))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.status").value(401))
-                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.message").value("인증된 사용자 정보가 없습니다."));
     }
 
     @Test

--- a/src/test/java/org/sani/algolog/security/oauth/OAuthMemberServiceTest.java
+++ b/src/test/java/org/sani/algolog/security/oauth/OAuthMemberServiceTest.java
@@ -1,0 +1,110 @@
+package org.sani.algolog.security.oauth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.member.entity.Provider;
+import org.sani.algolog.domain.member.entity.Role;
+import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.global.error.exception.ConflictException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthMemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private OAuthMemberService oauthMemberService;
+
+    @Test
+    @DisplayName("existing github member is reused")
+    void reuseExistingGithubMember() {
+        GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(123L, "octocat", "The Octocat");
+        Member member = Member.builder()
+                .email(userInfo.canonicalEmail())
+                .nickname("octocat")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+
+        when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.of(member));
+
+        Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
+
+        assertThat(result).isSameAs(member);
+    }
+
+    @Test
+    @DisplayName("member with same canonical email but different provider is rejected")
+    void rejectDifferentProvider() {
+        GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(123L, "octocat", "The Octocat");
+        Member member = Member.builder()
+                .email(userInfo.canonicalEmail())
+                .nickname("octocat")
+                .provider(Provider.KAKAO)
+                .role(Role.USER)
+                .build();
+
+        when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.of(member));
+
+        assertThatThrownBy(() -> oauthMemberService.getOrCreateGithubMember(userInfo))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("이미 다른 로그인 방식으로 가입된 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("new github member is created with unique nickname")
+    void createGithubMember() {
+        GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(123L, "octocat", "The Octocat");
+        Member savedMember = Member.builder()
+                .email(userInfo.canonicalEmail())
+                .nickname("The-Octocat1")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+
+        when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("The-Octocat")).thenReturn(Optional.of(savedMember));
+        when(memberRepository.findByNickname("The-Octocat1")).thenReturn(Optional.empty());
+        when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+        Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
+
+        assertThat(result.getEmail()).isEqualTo(userInfo.canonicalEmail());
+        assertThat(result.getNickname()).isEqualTo("The-Octocat1");
+        assertThat(result.getProvider()).isEqualTo(Provider.GITHUB);
+        assertThat(result.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    @DisplayName("short nickname falls back to github id based nickname")
+    void fallbackNickname() {
+        GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(7L, "x", null);
+        Member savedMember = Member.builder()
+                .email(userInfo.canonicalEmail())
+                .nickname("gh7")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+
+        when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("gh7")).thenReturn(Optional.empty());
+        when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+        Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
+
+        assertThat(result.getNickname()).isEqualTo("gh7");
+    }
+}

--- a/src/test/java/org/sani/algolog/security/oauth/OAuthMemberServiceTest.java
+++ b/src/test/java/org/sani/algolog/security/oauth/OAuthMemberServiceTest.java
@@ -11,6 +11,7 @@ import org.sani.algolog.domain.member.entity.Provider;
 import org.sani.algolog.domain.member.entity.Role;
 import org.sani.algolog.domain.member.repository.MemberRepository;
 import org.sani.algolog.global.error.exception.ConflictException;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
 
@@ -106,5 +107,90 @@ class OAuthMemberServiceTest {
         Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
 
         assertThat(result.getNickname()).isEqualTo("gh7");
+    }
+
+    @Test
+    @DisplayName("long nickname is truncated to 20 characters before uniqueness check")
+    void truncateLongNicknameBeforeCheckingUniqueness() {
+        GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(123L, "octocat", "abcdefghijklmnopqrstuv");
+        Member savedMember = Member.builder()
+                .email(userInfo.canonicalEmail())
+                .nickname("abcdefghijklmnopqrst")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+
+        when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("abcdefghijklmnopqrst")).thenReturn(Optional.empty());
+        when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+        Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
+
+        assertThat(result.getEmail()).isEqualTo(userInfo.canonicalEmail());
+        assertThat(result.getNickname()).isEqualTo("abcdefghijklmnopqrst");
+        assertThat(result.getProvider()).isEqualTo(Provider.GITHUB);
+        assertThat(result.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    @DisplayName("nickname suffix increments until an available candidate is found")
+    void incrementNicknameSuffixAfterCollisions() {
+        GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(123L, "nickname", null);
+        Member occupied = Member.builder()
+                .email("occupied@users.noreply.github.com")
+                .nickname("nickname")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+        Member occupiedWithSuffix = Member.builder()
+                .email("occupied2@users.noreply.github.com")
+                .nickname("nickname1")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+        Member savedMember = Member.builder()
+                .email(userInfo.canonicalEmail())
+                .nickname("nickname2")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+
+        when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("nickname")).thenReturn(Optional.of(occupied));
+        when(memberRepository.findByNickname("nickname1")).thenReturn(Optional.of(occupiedWithSuffix));
+        when(memberRepository.findByNickname("nickname2")).thenReturn(Optional.empty());
+        when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+        Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
+
+        assertThat(result.getEmail()).isEqualTo(userInfo.canonicalEmail());
+        assertThat(result.getNickname()).isEqualTo("nickname2");
+        assertThat(result.getProvider()).isEqualTo(Provider.GITHUB);
+        assertThat(result.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    @DisplayName("nickname save collision retries with next candidate")
+    void retryWhenNicknameSaveCollides() {
+        GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(123L, "nickname", null);
+        Member savedMember = Member.builder()
+                .email(userInfo.canonicalEmail())
+                .nickname("nickname1")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+
+        when(memberRepository.findByEmail(userInfo.canonicalEmail()))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("nickname")).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("nickname1")).thenReturn(Optional.empty());
+        when(memberRepository.save(any(Member.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate nickname"))
+                .thenReturn(savedMember);
+
+        Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
+
+        assertThat(result.getNickname()).isEqualTo("nickname1");
     }
 }

--- a/src/test/java/org/sani/algolog/security/oauth/OAuthMemberServiceTest.java
+++ b/src/test/java/org/sani/algolog/security/oauth/OAuthMemberServiceTest.java
@@ -71,48 +71,71 @@ class OAuthMemberServiceTest {
         GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(123L, "octocat", "The Octocat");
         Member savedMember = Member.builder()
                 .email(userInfo.canonicalEmail())
-                .nickname("The-Octocat1")
+                .nickname("octocat1")
                 .provider(Provider.GITHUB)
                 .role(Role.USER)
                 .build();
 
         when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.empty());
-        when(memberRepository.findByNickname("The-Octocat")).thenReturn(Optional.of(savedMember));
-        when(memberRepository.findByNickname("The-Octocat1")).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("octocat")).thenReturn(Optional.of(savedMember));
+        when(memberRepository.findByNickname("octocat1")).thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
 
         Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
 
         assertThat(result.getEmail()).isEqualTo(userInfo.canonicalEmail());
-        assertThat(result.getNickname()).isEqualTo("The-Octocat1");
+        assertThat(result.getNickname()).isEqualTo("octocat1");
         assertThat(result.getProvider()).isEqualTo(Provider.GITHUB);
         assertThat(result.getRole()).isEqualTo(Role.USER);
     }
 
     @Test
-    @DisplayName("short nickname falls back to github id based nickname")
-    void fallbackNickname() {
+    @DisplayName("single character login is used as nickname")
+    void useSingleCharacterLoginAsNickname() {
         GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(7L, "x", null);
         Member savedMember = Member.builder()
                 .email(userInfo.canonicalEmail())
-                .nickname("gh7")
+                .nickname("x")
                 .provider(Provider.GITHUB)
                 .role(Role.USER)
                 .build();
 
         when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.empty());
-        when(memberRepository.findByNickname("gh7")).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("x")).thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
 
         Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
 
-        assertThat(result.getNickname()).isEqualTo("gh7");
+        assertThat(result.getNickname()).isEqualTo("x");
     }
 
     @Test
     @DisplayName("long nickname is truncated to 20 characters before uniqueness check")
     void truncateLongNicknameBeforeCheckingUniqueness() {
         GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(123L, "octocat", "abcdefghijklmnopqrstuv");
+        Member savedMember = Member.builder()
+                .email(userInfo.canonicalEmail())
+                .nickname("octocat")
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+
+        when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("octocat")).thenReturn(Optional.empty());
+        when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
+
+        Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
+
+        assertThat(result.getEmail()).isEqualTo(userInfo.canonicalEmail());
+        assertThat(result.getNickname()).isEqualTo("octocat");
+        assertThat(result.getProvider()).isEqualTo(Provider.GITHUB);
+        assertThat(result.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    @DisplayName("long github login is truncated to 20 characters before uniqueness check")
+    void truncateLongLoginBeforeCheckingUniqueness() {
+        GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(123L, "abcdefghijklmnopqrstuv", "The Octocat");
         Member savedMember = Member.builder()
                 .email(userInfo.canonicalEmail())
                 .nickname("abcdefghijklmnopqrst")


### PR DESCRIPTION
## 🎫 관련 이슈 (Issue)
Closes #29

## 🛠️ 작업 내용 (Changes)
- [x] Spring Security 기반 `/api/**` 인증 체인과 API 전용 401/403 JSON 응답 처리 추가
- [x] GitHub OAuth 사용자 정보를 `Member`와 매핑하고 `@CurrentMemberId`가 인증 principal에서 member id를 읽도록 전환
- [x] Swagger/README 인증 설명을 GitHub OAuth 기준으로 갱신하고, 관련 WebMvc/서비스 테스트 보강

## 📸 스크린샷 (Optional)
- 없음

## 🤖 자가 점검 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 💬 리뷰 포인트 (Review Point)

- `CurrentMemberIdArgumentResolver`가 SecurityContext 및 세션 fallback으로 현재 사용자를 읽는 방식이 이후 JWT 전환에도 자연스러운지 확인 부탁드립니다.
- GitHub 사용자 정보를 canonical email(`github-{id}@users.noreply.github.com`)로 저장하는 전략이 현재 회원 모델 제약과 잘 맞는지 확인 부탁드립니다.
