### PR TITLE
[FEAT] 학습 잔디(Heatmap) 조회 API 구현

### DIFF
--- a/src/main/java/org/sani/algolog/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/org/sani/algolog/domain/dashboard/controller/DashboardController.java
@@ -1,0 +1,34 @@
+package org.sani.algolog.domain.dashboard.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.domain.dashboard.dto.HeatmapDayResponse;
+import org.sani.algolog.domain.dashboard.service.DashboardQueryService;
+import org.sani.algolog.global.common.ApiResponse;
+import org.sani.algolog.security.resolver.CurrentMemberId;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Dashboard", description = "Dashboard query APIs")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/dashboard")
+public class DashboardController {
+
+    private final DashboardQueryService dashboardQueryService;
+
+    @Operation(
+            summary = "Get heatmap data",
+            description = "Returns daily solution counts for the currently authenticated member."
+    )
+    @GetMapping("/heatmap")
+    public ApiResponse<List<HeatmapDayResponse>> getHeatmap(
+            @CurrentMemberId Long memberId
+    ) {
+        return ApiResponse.success(dashboardQueryService.getHeatmap(memberId));
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/dashboard/dto/HeatmapDayResponse.java
+++ b/src/main/java/org/sani/algolog/domain/dashboard/dto/HeatmapDayResponse.java
@@ -1,0 +1,15 @@
+package org.sani.algolog.domain.dashboard.dto;
+
+import org.sani.algolog.query.dto.HeatmapDailyCountRow;
+
+import java.time.LocalDate;
+
+public record HeatmapDayResponse(
+        LocalDate date,
+        long solvedCount
+) {
+
+    public static HeatmapDayResponse from(HeatmapDailyCountRow row) {
+        return new HeatmapDayResponse(row.solvedDate(), row.solvedCount());
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/dashboard/service/DashboardQueryService.java
+++ b/src/main/java/org/sani/algolog/domain/dashboard/service/DashboardQueryService.java
@@ -1,0 +1,41 @@
+package org.sani.algolog.domain.dashboard.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.sani.algolog.domain.dashboard.dto.HeatmapDayResponse;
+import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.query.mapper.HeatmapQueryMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardQueryService {
+
+    private static final int HEATMAP_LOOKBACK_DAYS = 365;
+
+    private final HeatmapQueryMapper heatmapQueryMapper;
+    private final MemberRepository memberRepository;
+
+    public List<HeatmapDayResponse> getHeatmap(Long memberId) {
+        validateMember(memberId);
+
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(HEATMAP_LOOKBACK_DAYS - 1L);
+
+        return heatmapQueryMapper.findDailyCountsByMemberIdAndDateRange(memberId, startDate, endDate)
+                .stream()
+                .map(HeatmapDayResponse::from)
+                .toList();
+    }
+
+    private void validateMember(Long memberId) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new EntityNotFoundException("Member not found: " + memberId);
+        }
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/dashboard/service/DashboardQueryService.java
+++ b/src/main/java/org/sani/algolog/domain/dashboard/service/DashboardQueryService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -17,6 +18,7 @@ import java.util.List;
 public class DashboardQueryService {
 
     private static final int HEATMAP_LOOKBACK_DAYS = 365;
+    private static final ZoneId HEATMAP_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final HeatmapQueryMapper heatmapQueryMapper;
     private final MemberRepository memberRepository;
@@ -24,10 +26,14 @@ public class DashboardQueryService {
     public List<HeatmapDayResponse> getHeatmap(Long memberId) {
         validateMember(memberId);
 
-        LocalDate endDate = LocalDate.now();
+        LocalDate endDate = LocalDate.now(HEATMAP_ZONE_ID);
         LocalDate startDate = endDate.minusDays(HEATMAP_LOOKBACK_DAYS - 1L);
 
-        return heatmapQueryMapper.findDailyCountsByMemberIdAndDateRange(memberId, startDate, endDate)
+        return heatmapQueryMapper.findDailyCountsByMemberIdAndDateRange(
+                        memberId,
+                        startDate.atStartOfDay(),
+                        endDate.atStartOfDay().plusDays(1)
+                )
                 .stream()
                 .map(HeatmapDayResponse::from)
                 .toList();

--- a/src/main/java/org/sani/algolog/query/dto/HeatmapDailyCountRow.java
+++ b/src/main/java/org/sani/algolog/query/dto/HeatmapDailyCountRow.java
@@ -1,0 +1,9 @@
+package org.sani.algolog.query.dto;
+
+import java.time.LocalDate;
+
+public record HeatmapDailyCountRow(
+        LocalDate solvedDate,
+        long solvedCount
+) {
+}

--- a/src/main/java/org/sani/algolog/query/mapper/HeatmapQueryMapper.java
+++ b/src/main/java/org/sani/algolog/query/mapper/HeatmapQueryMapper.java
@@ -1,0 +1,18 @@
+package org.sani.algolog.query.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.sani.algolog.query.dto.HeatmapDailyCountRow;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Mapper
+public interface HeatmapQueryMapper {
+
+    List<HeatmapDailyCountRow> findDailyCountsByMemberIdAndDateRange(
+            @Param("memberId") Long memberId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+}

--- a/src/main/java/org/sani/algolog/query/mapper/HeatmapQueryMapper.java
+++ b/src/main/java/org/sani/algolog/query/mapper/HeatmapQueryMapper.java
@@ -4,7 +4,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.sani.algolog.query.dto.HeatmapDailyCountRow;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper
@@ -12,7 +12,7 @@ public interface HeatmapQueryMapper {
 
     List<HeatmapDailyCountRow> findDailyCountsByMemberIdAndDateRange(
             @Param("memberId") Long memberId,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endExclusiveDateTime") LocalDateTime endExclusiveDateTime
     );
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,8 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-
+mybatis.mapper-locations=classpath:/mapper/**/*.xml
+#spring.profiles.active=local
 # Configure these environment variables to enable GitHub OAuth login.
 # GITHUB_CLIENT_ID=...
 # GITHUB_CLIENT_SECRET=...

--- a/src/main/resources/mapper/dashboard/HeatmapQueryMapper.xml
+++ b/src/main/resources/mapper/dashboard/HeatmapQueryMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.sani.algolog.query.mapper.HeatmapQueryMapper">
+
+    <select id="findDailyCountsByMemberIdAndDateRange"
+            resultType="org.sani.algolog.query.dto.HeatmapDailyCountRow">
+        SELECT
+            CAST(s.created_at AS DATE) AS solvedDate,
+            COUNT(*) AS solvedCount
+        FROM solution s
+        WHERE s.member_id = #{memberId}
+          AND CAST(s.created_at AS DATE) BETWEEN #{startDate} AND #{endDate}
+        GROUP BY CAST(s.created_at AS DATE)
+        ORDER BY solvedDate ASC
+    </select>
+</mapper>

--- a/src/main/resources/mapper/dashboard/HeatmapQueryMapper.xml
+++ b/src/main/resources/mapper/dashboard/HeatmapQueryMapper.xml
@@ -11,7 +11,9 @@
             COUNT(*) AS solvedCount
         FROM solution s
         WHERE s.member_id = #{memberId}
-          AND CAST(s.created_at AS DATE) BETWEEN #{startDate} AND #{endDate}
+          AND s.is_solved = true
+          AND s.created_at >= #{startDateTime}
+          AND s.created_at &lt; #{endExclusiveDateTime}
         GROUP BY CAST(s.created_at AS DATE)
         ORDER BY solvedDate ASC
     </select>

--- a/src/test/java/org/sani/algolog/domain/dashboard/controller/DashboardControllerSecurityIT.java
+++ b/src/test/java/org/sani/algolog/domain/dashboard/controller/DashboardControllerSecurityIT.java
@@ -1,0 +1,32 @@
+package org.sani.algolog.domain.dashboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class DashboardControllerSecurityIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("missing authentication is handled by security entry point for dashboard heatmap")
+    void missingAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/dashboard/heatmap"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+}

--- a/src/test/java/org/sani/algolog/domain/dashboard/controller/DashboardControllerTest.java
+++ b/src/test/java/org/sani/algolog/domain/dashboard/controller/DashboardControllerTest.java
@@ -1,0 +1,78 @@
+package org.sani.algolog.domain.dashboard.controller;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sani.algolog.domain.dashboard.dto.HeatmapDayResponse;
+import org.sani.algolog.domain.dashboard.service.DashboardQueryService;
+import org.sani.algolog.global.config.WebConfig;
+import org.sani.algolog.global.error.GlobalExceptionHandler;
+import org.sani.algolog.security.oauth.AlgoLogAuthenticatedPrincipal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = DashboardController.class)
+@Import({GlobalExceptionHandler.class, WebConfig.class})
+@AutoConfigureMockMvc(addFilters = false)
+class DashboardControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DashboardQueryService dashboardQueryService;
+
+    @Test
+    @DisplayName("GET /api/v1/dashboard/heatmap returns heatmap data")
+    void getHeatmap() throws Exception {
+        when(dashboardQueryService.getHeatmap(1L)).thenReturn(List.of(
+                new HeatmapDayResponse(LocalDate.of(2026, 3, 28), 2),
+                new HeatmapDayResponse(LocalDate.of(2026, 3, 29), 1)
+        ));
+
+        mockMvc.perform(get("/api/v1/dashboard/heatmap")
+                        .with(authentication(authenticatedMember(1L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].date").value("2026-03-28"))
+                .andExpect(jsonPath("$.data[0].solvedCount").value(2))
+                .andExpect(jsonPath("$.data[1].date").value("2026-03-29"))
+                .andExpect(jsonPath("$.data[1].solvedCount").value(1));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/dashboard/heatmap returns NOT_FOUND when member is missing")
+    void getHeatmapMemberNotFound() throws Exception {
+        when(dashboardQueryService.getHeatmap(1L))
+                .thenThrow(new EntityNotFoundException("Member not found: 1"));
+
+        mockMvc.perform(get("/api/v1/dashboard/heatmap")
+                        .with(authentication(authenticatedMember(1L))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    private TestingAuthenticationToken authenticatedMember(Long memberId) {
+        AlgoLogAuthenticatedPrincipal principal = () -> memberId;
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(principal, null);
+        authentication.setAuthenticated(true);
+        return authentication;
+    }
+}

--- a/src/test/java/org/sani/algolog/query/mapper/HeatmapQueryMapperTest.java
+++ b/src/test/java/org/sani/algolog/query/mapper/HeatmapQueryMapperTest.java
@@ -1,0 +1,123 @@
+package org.sani.algolog.query.mapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.member.entity.Provider;
+import org.sani.algolog.domain.member.entity.Role;
+import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.domain.problem.entity.Platform;
+import org.sani.algolog.domain.problem.entity.Problem;
+import org.sani.algolog.domain.problem.repository.ProblemRepository;
+import org.sani.algolog.domain.solution.entity.Solution;
+import org.sani.algolog.domain.solution.repository.SolutionRepository;
+import org.sani.algolog.query.dto.HeatmapDailyCountRow;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class HeatmapQueryMapperTest {
+
+    @Autowired
+    private HeatmapQueryMapper heatmapQueryMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private SolutionRepository solutionRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("member heatmap is grouped by created date and ordered ascending")
+    void findDailyCountsByMemberIdAndDateRange() {
+        Member owner = memberRepository.save(member("owner@example.com", "owner"));
+        Member other = memberRepository.save(member("other@example.com", "other"));
+        Problem problem = problemRepository.save(problem("1000"));
+
+        saveSolution(owner, problem, LocalDateTime.of(2026, 3, 20, 10, 0));
+        saveSolution(owner, problem, LocalDateTime.of(2026, 3, 20, 18, 0));
+        saveSolution(owner, problem, LocalDateTime.of(2026, 3, 21, 9, 0));
+        saveSolution(other, problem, LocalDateTime.of(2026, 3, 20, 12, 0));
+
+        List<HeatmapDailyCountRow> rows = heatmapQueryMapper.findDailyCountsByMemberIdAndDateRange(
+                owner.getId(),
+                LocalDate.of(2026, 3, 19),
+                LocalDate.of(2026, 3, 21)
+        );
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).solvedDate()).isEqualTo(LocalDate.of(2026, 3, 20));
+        assertThat(rows.get(0).solvedCount()).isEqualTo(2);
+        assertThat(rows.get(1).solvedDate()).isEqualTo(LocalDate.of(2026, 3, 21));
+        assertThat(rows.get(1).solvedCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("member heatmap returns empty list when there is no data in range")
+    void findDailyCountsByMemberIdAndDateRangeWhenEmpty() {
+        Member owner = memberRepository.save(member("empty@example.com", "empty"));
+
+        List<HeatmapDailyCountRow> rows = heatmapQueryMapper.findDailyCountsByMemberIdAndDateRange(
+                owner.getId(),
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 1, 31)
+        );
+
+        assertThat(rows).isEmpty();
+    }
+
+    private void saveSolution(Member member, Problem problem, LocalDateTime createdAt) {
+        Solution solution = solutionRepository.save(Solution.builder()
+                .code("public class Main {}")
+                .timeElapsed(100)
+                .isSolved(true)
+                .memoMarkdown("memo")
+                .problem(problem)
+                .member(member)
+                .build());
+
+        jdbcTemplate.update(
+                "UPDATE solution SET created_at = ?, updated_at = ? WHERE id = ?",
+                Timestamp.valueOf(createdAt),
+                Timestamp.valueOf(createdAt),
+                solution.getId()
+        );
+    }
+
+    private Member member(String email, String nickname) {
+        return Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+    }
+
+    private Problem problem(String externalProblemId) {
+        return Problem.builder()
+                .platform(Platform.BOJ)
+                .externalProblemId(externalProblemId)
+                .title("A+B")
+                .problemUrl("https://www.acmicpc.net/problem/" + externalProblemId)
+                .difficulty("Bronze V")
+                .build();
+    }
+}

--- a/src/test/java/org/sani/algolog/query/mapper/HeatmapQueryMapperTest.java
+++ b/src/test/java/org/sani/algolog/query/mapper/HeatmapQueryMapperTest.java
@@ -55,12 +55,14 @@ class HeatmapQueryMapperTest {
         saveSolution(owner, problem, LocalDateTime.of(2026, 3, 20, 10, 0));
         saveSolution(owner, problem, LocalDateTime.of(2026, 3, 20, 18, 0));
         saveSolution(owner, problem, LocalDateTime.of(2026, 3, 21, 9, 0));
+        saveSolution(owner, problem, false, LocalDateTime.of(2026, 3, 21, 10, 0));
         saveSolution(other, problem, LocalDateTime.of(2026, 3, 20, 12, 0));
+        saveSolution(owner, problem, LocalDateTime.of(2026, 3, 22, 0, 0));
 
         List<HeatmapDailyCountRow> rows = heatmapQueryMapper.findDailyCountsByMemberIdAndDateRange(
                 owner.getId(),
-                LocalDate.of(2026, 3, 19),
-                LocalDate.of(2026, 3, 21)
+                LocalDateTime.of(2026, 3, 19, 0, 0),
+                LocalDateTime.of(2026, 3, 22, 0, 0)
         );
 
         assertThat(rows).hasSize(2);
@@ -77,18 +79,22 @@ class HeatmapQueryMapperTest {
 
         List<HeatmapDailyCountRow> rows = heatmapQueryMapper.findDailyCountsByMemberIdAndDateRange(
                 owner.getId(),
-                LocalDate.of(2026, 1, 1),
-                LocalDate.of(2026, 1, 31)
+                LocalDateTime.of(2026, 1, 1, 0, 0),
+                LocalDateTime.of(2026, 2, 1, 0, 0)
         );
 
         assertThat(rows).isEmpty();
     }
 
     private void saveSolution(Member member, Problem problem, LocalDateTime createdAt) {
+        saveSolution(member, problem, true, createdAt);
+    }
+
+    private void saveSolution(Member member, Problem problem, boolean isSolved, LocalDateTime createdAt) {
         Solution solution = solutionRepository.save(Solution.builder()
                 .code("public class Main {}")
                 .timeElapsed(100)
-                .isSolved(true)
+                .isSolved(isSolved)
                 .memoMarkdown("memo")
                 .problem(problem)
                 .member(member)

--- a/src/test/java/org/sani/algolog/security/oauth/OAuthMemberServiceTest.java
+++ b/src/test/java/org/sani/algolog/security/oauth/OAuthMemberServiceTest.java
@@ -90,23 +90,23 @@ class OAuthMemberServiceTest {
     }
 
     @Test
-    @DisplayName("single character login is used as nickname")
+    @DisplayName("single character login falls back to github id based nickname")
     void useSingleCharacterLoginAsNickname() {
         GithubOAuthUserInfo userInfo = new GithubOAuthUserInfo(7L, "x", null);
         Member savedMember = Member.builder()
                 .email(userInfo.canonicalEmail())
-                .nickname("x")
+                .nickname("gh7")
                 .provider(Provider.GITHUB)
                 .role(Role.USER)
                 .build();
 
         when(memberRepository.findByEmail(userInfo.canonicalEmail())).thenReturn(Optional.empty());
-        when(memberRepository.findByNickname("x")).thenReturn(Optional.empty());
+        when(memberRepository.findByNickname("gh7")).thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
 
         Member result = oauthMemberService.getOrCreateGithubMember(userInfo);
 
-        assertThat(result.getNickname()).isEqualTo("x");
+        assertThat(result.getNickname()).isEqualTo("gh7");
     }
 
     @Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -5,3 +5,4 @@ spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
+mybatis.mapper-locations=classpath:/mapper/**/*.xml


### PR DESCRIPTION
## 🎫 관련 이슈 (Issue)
Closes #31

## 🛠️ 작업 내용 (Changes)
- [x] MyBatis 기반 Heatmap 조회용 DTO, Mapper, XML 쿼리를 추가했습니다.
- [x] `GET /api/v1/dashboard/heatmap` API와 대시보드 조회 서비스를 구현했습니다.
- [x] Dashboard API/Mapper 테스트를 추가하고 OAuth 닉네임 규칙에 맞게 기존 테스트를 정리했습니다.

## 📸 스크린샷 (Optional)
해당 없음

## 🤖 자가 점검 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 💬 리뷰 포인트 (Review Point)

- Heatmap 조회 범위를 최근 1년으로 고정했는데, 프론트 요구사항과 맞는지 확인 부탁드립니다.
- 집계 기준을 `solution.created_at`의 날짜 단위로 두었는데, 타임존 처리 기대와 일치하는지 봐주시면 됩니다.
- 인증 사용자의 memberId를 기반으로만 조회되도록 연결했으니, 대시보드 응답 구조가 프론트 히트맵 컴포넌트에 바로 연결
가능한지 확인 부탁드립니다.