### PR TITLE
[FEAT] 플랫폼별/난이도별 풀이 통계 API 구현

### DIFF
--- a/src/main/java/org/sani/algolog/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/org/sani/algolog/domain/dashboard/controller/DashboardController.java
@@ -3,6 +3,7 @@ package org.sani.algolog.domain.dashboard.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.sani.algolog.domain.dashboard.dto.DashboardSummaryResponse;
 import org.sani.algolog.domain.dashboard.dto.HeatmapDayResponse;
 import org.sani.algolog.domain.dashboard.service.DashboardQueryService;
 import org.sani.algolog.global.common.ApiResponse;
@@ -30,5 +31,16 @@ public class DashboardController {
             @CurrentMemberId Long memberId
     ) {
         return ApiResponse.success(dashboardQueryService.getHeatmap(memberId));
+    }
+
+    @Operation(
+            summary = "Get dashboard summary data",
+            description = "Returns summary counts grouped for the currently authenticated member."
+    )
+    @GetMapping("/summary")
+    public ApiResponse<DashboardSummaryResponse> getSummary(
+            @CurrentMemberId Long memberId
+    ) {
+        return ApiResponse.success(dashboardQueryService.getSummary(memberId));
     }
 }

--- a/src/main/java/org/sani/algolog/domain/dashboard/dto/DashboardCountResponse.java
+++ b/src/main/java/org/sani/algolog/domain/dashboard/dto/DashboardCountResponse.java
@@ -1,0 +1,13 @@
+package org.sani.algolog.domain.dashboard.dto;
+
+import org.sani.algolog.query.dto.SummaryCountRow;
+
+public record DashboardCountResponse(
+        String name,
+        long count
+) {
+
+    public static DashboardCountResponse from(SummaryCountRow row) {
+        return new DashboardCountResponse(row.name(), row.count());
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/dashboard/dto/DashboardSummaryResponse.java
+++ b/src/main/java/org/sani/algolog/domain/dashboard/dto/DashboardSummaryResponse.java
@@ -1,0 +1,28 @@
+package org.sani.algolog.domain.dashboard.dto;
+
+import org.sani.algolog.query.dto.SummaryTotalsRow;
+
+import java.util.List;
+
+public record DashboardSummaryResponse(
+        long totalCount,
+        long solvedCount,
+        long failedCount,
+        List<DashboardCountResponse> platformCounts,
+        List<DashboardCountResponse> difficultyCounts
+) {
+
+    public static DashboardSummaryResponse of(
+            SummaryTotalsRow totals,
+            List<DashboardCountResponse> platformCounts,
+            List<DashboardCountResponse> difficultyCounts
+    ) {
+        return new DashboardSummaryResponse(
+                totals.totalCount(),
+                totals.solvedCount(),
+                totals.failedCount(),
+                platformCounts,
+                difficultyCounts
+        );
+    }
+}

--- a/src/main/java/org/sani/algolog/domain/dashboard/service/DashboardQueryService.java
+++ b/src/main/java/org/sani/algolog/domain/dashboard/service/DashboardQueryService.java
@@ -2,8 +2,12 @@ package org.sani.algolog.domain.dashboard.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.sani.algolog.domain.dashboard.dto.DashboardCountResponse;
+import org.sani.algolog.domain.dashboard.dto.DashboardSummaryResponse;
 import org.sani.algolog.domain.dashboard.dto.HeatmapDayResponse;
 import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.query.dto.SummaryTotalsRow;
+import org.sani.algolog.query.mapper.DashboardSummaryQueryMapper;
 import org.sani.algolog.query.mapper.HeatmapQueryMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +24,7 @@ public class DashboardQueryService {
     private static final int HEATMAP_LOOKBACK_DAYS = 365;
     private static final ZoneId HEATMAP_ZONE_ID = ZoneId.of("Asia/Seoul");
 
+    private final DashboardSummaryQueryMapper dashboardSummaryQueryMapper;
     private final HeatmapQueryMapper heatmapQueryMapper;
     private final MemberRepository memberRepository;
 
@@ -37,6 +42,22 @@ public class DashboardQueryService {
                 .stream()
                 .map(HeatmapDayResponse::from)
                 .toList();
+    }
+
+    public DashboardSummaryResponse getSummary(Long memberId) {
+        validateMember(memberId);
+
+        SummaryTotalsRow totals = dashboardSummaryQueryMapper.findSummaryTotalsByMemberId(memberId);
+
+        return DashboardSummaryResponse.of(
+                totals == null ? SummaryTotalsRow.empty() : totals,
+                dashboardSummaryQueryMapper.findPlatformCountsByMemberId(memberId).stream()
+                        .map(DashboardCountResponse::from)
+                        .toList(),
+                dashboardSummaryQueryMapper.findDifficultyCountsByMemberId(memberId).stream()
+                        .map(DashboardCountResponse::from)
+                        .toList()
+        );
     }
 
     private void validateMember(Long memberId) {

--- a/src/main/java/org/sani/algolog/query/dto/SummaryCountRow.java
+++ b/src/main/java/org/sani/algolog/query/dto/SummaryCountRow.java
@@ -1,0 +1,7 @@
+package org.sani.algolog.query.dto;
+
+public record SummaryCountRow(
+        String name,
+        long count
+) {
+}

--- a/src/main/java/org/sani/algolog/query/dto/SummaryTotalsRow.java
+++ b/src/main/java/org/sani/algolog/query/dto/SummaryTotalsRow.java
@@ -1,0 +1,12 @@
+package org.sani.algolog.query.dto;
+
+public record SummaryTotalsRow(
+        long totalCount,
+        long solvedCount,
+        long failedCount
+) {
+
+    public static SummaryTotalsRow empty() {
+        return new SummaryTotalsRow(0L, 0L, 0L);
+    }
+}

--- a/src/main/java/org/sani/algolog/query/mapper/DashboardSummaryQueryMapper.java
+++ b/src/main/java/org/sani/algolog/query/mapper/DashboardSummaryQueryMapper.java
@@ -1,0 +1,18 @@
+package org.sani.algolog.query.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.sani.algolog.query.dto.SummaryCountRow;
+import org.sani.algolog.query.dto.SummaryTotalsRow;
+
+import java.util.List;
+
+@Mapper
+public interface DashboardSummaryQueryMapper {
+
+    SummaryTotalsRow findSummaryTotalsByMemberId(@Param("memberId") Long memberId);
+
+    List<SummaryCountRow> findPlatformCountsByMemberId(@Param("memberId") Long memberId);
+
+    List<SummaryCountRow> findDifficultyCountsByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/resources/mapper/dashboard/DashboardSummaryQueryMapper.xml
+++ b/src/main/resources/mapper/dashboard/DashboardSummaryQueryMapper.xml
@@ -17,7 +17,7 @@
     <select id="findPlatformCountsByMemberId"
             resultType="org.sani.algolog.query.dto.SummaryCountRow">
         SELECT
-            CAST(p.platform AS VARCHAR) AS name,
+            p.platform AS name,
             COUNT(*) AS count
         FROM solution s
         INNER JOIN problems p ON p.id = s.problem_id

--- a/src/main/resources/mapper/dashboard/DashboardSummaryQueryMapper.xml
+++ b/src/main/resources/mapper/dashboard/DashboardSummaryQueryMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.sani.algolog.query.mapper.DashboardSummaryQueryMapper">
+
+    <select id="findSummaryTotalsByMemberId"
+            resultType="org.sani.algolog.query.dto.SummaryTotalsRow">
+        SELECT
+            COUNT(*) AS totalCount,
+            COALESCE(SUM(CASE WHEN s.is_solved = true THEN 1 ELSE 0 END), 0) AS solvedCount,
+            COALESCE(SUM(CASE WHEN s.is_solved = false THEN 1 ELSE 0 END), 0) AS failedCount
+        FROM solution s
+        WHERE s.member_id = #{memberId}
+    </select>
+
+    <select id="findPlatformCountsByMemberId"
+            resultType="org.sani.algolog.query.dto.SummaryCountRow">
+        SELECT
+            CAST(p.platform AS VARCHAR) AS name,
+            COUNT(*) AS count
+        FROM solution s
+        INNER JOIN problems p ON p.id = s.problem_id
+        WHERE s.member_id = #{memberId}
+        GROUP BY p.platform
+        ORDER BY count DESC, name ASC
+    </select>
+
+    <select id="findDifficultyCountsByMemberId"
+            resultType="org.sani.algolog.query.dto.SummaryCountRow">
+        SELECT
+            p.difficulty AS name,
+            COUNT(*) AS count
+        FROM solution s
+        INNER JOIN problems p ON p.id = s.problem_id
+        WHERE s.member_id = #{memberId}
+        GROUP BY p.difficulty
+        ORDER BY count DESC, name ASC
+    </select>
+</mapper>

--- a/src/test/java/org/sani/algolog/domain/dashboard/controller/DashboardControllerSecurityIT.java
+++ b/src/test/java/org/sani/algolog/domain/dashboard/controller/DashboardControllerSecurityIT.java
@@ -29,4 +29,14 @@ class DashboardControllerSecurityIT {
                 .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
                 .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
     }
+
+    @Test
+    @DisplayName("missing authentication is handled by security entry point for dashboard summary")
+    void missingAuthenticationForSummary() throws Exception {
+        mockMvc.perform(get("/api/v1/dashboard/summary"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
 }

--- a/src/test/java/org/sani/algolog/domain/dashboard/controller/DashboardControllerTest.java
+++ b/src/test/java/org/sani/algolog/domain/dashboard/controller/DashboardControllerTest.java
@@ -3,6 +3,8 @@ package org.sani.algolog.domain.dashboard.controller;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.sani.algolog.domain.dashboard.dto.DashboardCountResponse;
+import org.sani.algolog.domain.dashboard.dto.DashboardSummaryResponse;
 import org.sani.algolog.domain.dashboard.dto.HeatmapDayResponse;
 import org.sani.algolog.domain.dashboard.service.DashboardQueryService;
 import org.sani.algolog.global.config.WebConfig;
@@ -57,12 +59,58 @@ class DashboardControllerTest {
     }
 
     @Test
+    @DisplayName("GET /api/v1/dashboard/summary returns dashboard summary data")
+    void getSummary() throws Exception {
+        when(dashboardQueryService.getSummary(1L)).thenReturn(new DashboardSummaryResponse(
+                5,
+                3,
+                2,
+                List.of(
+                        new DashboardCountResponse("BOJ", 3),
+                        new DashboardCountResponse("PROGRAMMERS", 2)
+                ),
+                List.of(
+                        new DashboardCountResponse("Gold 4", 2),
+                        new DashboardCountResponse("Silver 1", 1)
+                )
+        ));
+
+        mockMvc.perform(get("/api/v1/dashboard/summary")
+                        .with(authentication(authenticatedMember(1L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.totalCount").value(5))
+                .andExpect(jsonPath("$.data.solvedCount").value(3))
+                .andExpect(jsonPath("$.data.failedCount").value(2))
+                .andExpect(jsonPath("$.data.platformCounts.length()").value(2))
+                .andExpect(jsonPath("$.data.platformCounts[0].name").value("BOJ"))
+                .andExpect(jsonPath("$.data.platformCounts[0].count").value(3))
+                .andExpect(jsonPath("$.data.difficultyCounts.length()").value(2))
+                .andExpect(jsonPath("$.data.difficultyCounts[0].name").value("Gold 4"))
+                .andExpect(jsonPath("$.data.difficultyCounts[0].count").value(2));
+    }
+
+    @Test
     @DisplayName("GET /api/v1/dashboard/heatmap returns NOT_FOUND when member is missing")
     void getHeatmapMemberNotFound() throws Exception {
         when(dashboardQueryService.getHeatmap(1L))
                 .thenThrow(new EntityNotFoundException("Member not found: 1"));
 
         mockMvc.perform(get("/api/v1/dashboard/heatmap")
+                        .with(authentication(authenticatedMember(1L))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/dashboard/summary returns NOT_FOUND when member is missing")
+    void getSummaryMemberNotFound() throws Exception {
+        when(dashboardQueryService.getSummary(1L))
+                .thenThrow(new EntityNotFoundException("Member not found: 1"));
+
+        mockMvc.perform(get("/api/v1/dashboard/summary")
                         .with(authentication(authenticatedMember(1L))))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))

--- a/src/test/java/org/sani/algolog/query/mapper/DashboardSummaryQueryMapperTest.java
+++ b/src/test/java/org/sani/algolog/query/mapper/DashboardSummaryQueryMapperTest.java
@@ -1,0 +1,122 @@
+package org.sani.algolog.query.mapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.sani.algolog.domain.member.entity.Member;
+import org.sani.algolog.domain.member.entity.Provider;
+import org.sani.algolog.domain.member.entity.Role;
+import org.sani.algolog.domain.member.repository.MemberRepository;
+import org.sani.algolog.domain.problem.entity.Platform;
+import org.sani.algolog.domain.problem.entity.Problem;
+import org.sani.algolog.domain.problem.repository.ProblemRepository;
+import org.sani.algolog.domain.solution.entity.Solution;
+import org.sani.algolog.domain.solution.repository.SolutionRepository;
+import org.sani.algolog.query.dto.SummaryCountRow;
+import org.sani.algolog.query.dto.SummaryTotalsRow;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class DashboardSummaryQueryMapperTest {
+
+    @Autowired
+    private DashboardSummaryQueryMapper dashboardSummaryQueryMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private SolutionRepository solutionRepository;
+
+    @Test
+    @DisplayName("dashboard summary aggregates totals and group counts for a member")
+    void findDashboardSummaryByMemberId() {
+        Member owner = memberRepository.save(member("owner@example.com", "owner"));
+        Member other = memberRepository.save(member("other@example.com", "other"));
+
+        Problem bojGold = problemRepository.save(problem(Platform.BOJ, "1000", "Gold 4"));
+        Problem programmersGold = problemRepository.save(problem(Platform.PROGRAMMERS, "2000", "Gold 4"));
+        Problem bojSilver = problemRepository.save(problem(Platform.BOJ, "3000", "Silver 1"));
+
+        saveSolution(owner, bojGold, true);
+        saveSolution(owner, bojGold, false);
+        saveSolution(owner, programmersGold, true);
+        saveSolution(owner, bojSilver, true);
+        saveSolution(other, bojGold, true);
+
+        SummaryTotalsRow totals = dashboardSummaryQueryMapper.findSummaryTotalsByMemberId(owner.getId());
+        List<SummaryCountRow> platformCounts = dashboardSummaryQueryMapper.findPlatformCountsByMemberId(owner.getId());
+        List<SummaryCountRow> difficultyCounts = dashboardSummaryQueryMapper.findDifficultyCountsByMemberId(owner.getId());
+
+        assertThat(totals.totalCount()).isEqualTo(4);
+        assertThat(totals.solvedCount()).isEqualTo(3);
+        assertThat(totals.failedCount()).isEqualTo(1);
+
+        assertThat(platformCounts).containsExactly(
+                new SummaryCountRow("BOJ", 3),
+                new SummaryCountRow("PROGRAMMERS", 1)
+        );
+
+        assertThat(difficultyCounts).containsExactly(
+                new SummaryCountRow("Gold 4", 3),
+                new SummaryCountRow("Silver 1", 1)
+        );
+    }
+
+    @Test
+    @DisplayName("dashboard summary returns zeros and empty lists when member has no data")
+    void findDashboardSummaryByMemberIdWhenEmpty() {
+        Member owner = memberRepository.save(member("empty@example.com", "empty"));
+
+        SummaryTotalsRow totals = dashboardSummaryQueryMapper.findSummaryTotalsByMemberId(owner.getId());
+        List<SummaryCountRow> platformCounts = dashboardSummaryQueryMapper.findPlatformCountsByMemberId(owner.getId());
+        List<SummaryCountRow> difficultyCounts = dashboardSummaryQueryMapper.findDifficultyCountsByMemberId(owner.getId());
+
+        assertThat(totals.totalCount()).isEqualTo(0);
+        assertThat(totals.solvedCount()).isEqualTo(0);
+        assertThat(totals.failedCount()).isEqualTo(0);
+        assertThat(platformCounts).isEmpty();
+        assertThat(difficultyCounts).isEmpty();
+    }
+
+    private void saveSolution(Member member, Problem problem, boolean isSolved) {
+        solutionRepository.save(Solution.builder()
+                .code("public class Main {}")
+                .timeElapsed(100)
+                .isSolved(isSolved)
+                .memoMarkdown("memo")
+                .problem(problem)
+                .member(member)
+                .build());
+    }
+
+    private Member member(String email, String nickname) {
+        return Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .provider(Provider.GITHUB)
+                .role(Role.USER)
+                .build();
+    }
+
+    private Problem problem(Platform platform, String externalProblemId, String difficulty) {
+        return Problem.builder()
+                .platform(platform)
+                .externalProblemId(externalProblemId)
+                .title("Sample")
+                .problemUrl("https://example.com/problems/" + externalProblemId)
+                .difficulty(difficulty)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🎫 관련 이슈 (Issue)
Closes #32

## 🛠️ 작업 내용 (Changes)
- [x] MyBatis 기반 Dashboard summary 조회용 DTO, Mapper, XML 쿼리를 추가했습니다.
- [x] `GET /api/v1/dashboard/summary` API와 대시보드 조회 서비스를 구현했습니다.
- [x] Summary Mapper/API 테스트와 인증 테스트를 추가하고 `./gradlew test`를 통과했습니다.

## 📸 스크린샷 (Optional)
해당 없음

## 🤖 자가 점검 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 💬 리뷰 포인트 (Review Point)

- Summary 응답 구조(`totalCount`, `solvedCount`, `failedCount`, `platformCounts`, `difficultyCounts`)가 프론트 대시보드 카드/차트 요구와 맞는지 확인 부탁드립니다.
- 플랫폼별/난이도별 집계 정렬을 `count DESC, name ASC`로 고정했는데 프론트 사용 기대와 일치하는지 봐주시면 됩니다.
- Summary는 현재 누적 전체 풀이 기준으로 집계되도록 구현했으니, 기간 제한 없는 대시보드 요약 의도와 맞는지 확인 부탁드립니다.
