### PR TITLE
[CHORE] 프론트 개발용 OAuth 복귀 및 CORS 최소 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@
   - `GITHUB_CLIENT_SECRET`
 - 필요 scope: `read:user`, `user:email`
 - 로그인 진입 경로: `/oauth2/authorization/github`
+- 프론트 개발 서버 연동
+  - `algolog.frontend.app-url`: OAuth 성공/로그아웃 후 복귀할 프론트 URL
+  - `algolog.frontend.allowed-origin`: credential 기반 API 호출을 허용할 프론트 origin
+  - 기본값은 둘 다 `http://localhost:5173`
 
 ---
 

--- a/src/main/java/org/sani/algolog/global/config/SecurityConfig.java
+++ b/src/main/java/org/sani/algolog/global/config/SecurityConfig.java
@@ -3,15 +3,24 @@ package org.sani.algolog.global.config;
 import lombok.RequiredArgsConstructor;
 import org.sani.algolog.security.handler.ApiAccessDeniedHandler;
 import org.sani.algolog.security.handler.ApiAuthenticationEntryPoint;
+import org.sani.algolog.security.handler.FrontendRedirectAuthenticationSuccessHandler;
+import org.sani.algolog.security.handler.FrontendRedirectLogoutSuccessHandler;
 import org.sani.algolog.security.oauth.CustomOAuth2UserService;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -21,6 +30,12 @@ public class SecurityConfig {
     private final ApiAccessDeniedHandler apiAccessDeniedHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
 
+    @Value("${algolog.frontend.app-url:http://localhost:5173}")
+    private String frontendAppUrl;
+
+    @Value("${algolog.frontend.allowed-origin:http://localhost:5173}")
+    private String frontendAllowedOrigin;
+
     @Bean
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
@@ -28,9 +43,12 @@ public class SecurityConfig {
     ) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
-                .logout(logout -> logout.logoutSuccessUrl("/"))
+                .logout(logout -> logout.logoutSuccessHandler(
+                        new FrontendRedirectLogoutSuccessHandler(frontendAppUrl)
+                ))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
                                 "/",
@@ -58,9 +76,25 @@ public class SecurityConfig {
             http.oauth2Login(oauth2 -> oauth2
                     .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                     .loginPage("/oauth2/authorization/github")
+                    .successHandler(new FrontendRedirectAuthenticationSuccessHandler(frontendAppUrl))
             );
         }
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of(frontendAllowedOrigin));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+        source.registerCorsConfiguration("/logout", configuration);
+        source.registerCorsConfiguration("/oauth2/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/org/sani/algolog/security/handler/FrontendRedirectAuthenticationSuccessHandler.java
+++ b/src/main/java/org/sani/algolog/security/handler/FrontendRedirectAuthenticationSuccessHandler.java
@@ -1,0 +1,26 @@
+package org.sani.algolog.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+public class FrontendRedirectAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    public FrontendRedirectAuthenticationSuccessHandler(String targetUrl) {
+        setDefaultTargetUrl(targetUrl);
+        setAlwaysUseDefaultTargetUrl(true);
+    }
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException, ServletException {
+        super.onAuthenticationSuccess(request, response, authentication);
+    }
+}

--- a/src/main/java/org/sani/algolog/security/handler/FrontendRedirectLogoutSuccessHandler.java
+++ b/src/main/java/org/sani/algolog/security/handler/FrontendRedirectLogoutSuccessHandler.java
@@ -1,0 +1,27 @@
+package org.sani.algolog.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+import java.io.IOException;
+
+public class FrontendRedirectLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final String targetUrl;
+
+    public FrontendRedirectLogoutSuccessHandler(String targetUrl) {
+        this.targetUrl = targetUrl;
+    }
+
+    @Override
+    public void onLogoutSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException, ServletException {
+        response.sendRedirect(targetUrl);
+    }
+}

--- a/src/main/resources/application-local.properties.example
+++ b/src/main/resources/application-local.properties.example
@@ -13,3 +13,6 @@ spring.jpa.show-sql=true
 spring.security.oauth2.client.registration.github.client-id=YOUR_GITHUB_CLIENT_ID
 spring.security.oauth2.client.registration.github.client-secret=YOUR_GITHUB_CLIENT_SECRET
 spring.security.oauth2.client.registration.github.scope=read:user,user:email
+
+algolog.frontend.app-url=http://localhost:5173
+algolog.frontend.allowed-origin=http://localhost:5173

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ mybatis.mapper-locations=classpath:/mapper/**/*.xml
 # spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID}
 # spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET}
 # spring.security.oauth2.client.registration.github.scope=read:user,user:email
+algolog.frontend.app-url=http://localhost:5173
+algolog.frontend.allowed-origin=http://localhost:5173

--- a/src/test/java/org/sani/algolog/global/config/CorsConfigurationIT.java
+++ b/src/test/java/org/sani/algolog/global/config/CorsConfigurationIT.java
@@ -1,0 +1,33 @@
+package org.sani.algolog.global.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class CorsConfigurationIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("preflight request from frontend origin is allowed for API endpoints")
+    void allowFrontendOriginPreflight() throws Exception {
+        mockMvc.perform(options("/api/v1/solutions")
+                        .header("Origin", "http://localhost:5173")
+                        .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5173"))
+                .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+    }
+}

--- a/src/test/java/org/sani/algolog/security/handler/FrontendRedirectAuthenticationSuccessHandlerTest.java
+++ b/src/test/java/org/sani/algolog/security/handler/FrontendRedirectAuthenticationSuccessHandlerTest.java
@@ -1,0 +1,30 @@
+package org.sani.algolog.security.handler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FrontendRedirectAuthenticationSuccessHandlerTest {
+
+    @Test
+    @DisplayName("authentication success redirects to configured frontend URL")
+    void redirectsToFrontendUrl() throws Exception {
+        FrontendRedirectAuthenticationSuccessHandler handler =
+                new FrontendRedirectAuthenticationSuccessHandler("http://localhost:5173");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationSuccess(
+                request,
+                response,
+                new TestingAuthenticationToken("principal", "credentials")
+        );
+
+        assertThat(response.getRedirectedUrl()).isEqualTo("http://localhost:5173");
+    }
+}

--- a/src/test/java/org/sani/algolog/security/handler/FrontendRedirectLogoutSuccessHandlerTest.java
+++ b/src/test/java/org/sani/algolog/security/handler/FrontendRedirectLogoutSuccessHandlerTest.java
@@ -1,0 +1,25 @@
+package org.sani.algolog.security.handler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FrontendRedirectLogoutSuccessHandlerTest {
+
+    @Test
+    @DisplayName("logout success redirects to configured frontend URL")
+    void redirectsToFrontendUrl() throws Exception {
+        FrontendRedirectLogoutSuccessHandler handler =
+                new FrontendRedirectLogoutSuccessHandler("http://localhost:5173");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onLogoutSuccess(request, response, null);
+
+        assertThat(response.getRedirectedUrl()).isEqualTo("http://localhost:5173");
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -6,3 +6,5 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
 mybatis.mapper-locations=classpath:/mapper/**/*.xml
+algolog.frontend.app-url=http://localhost:5173
+algolog.frontend.allowed-origin=http://localhost:5173


### PR DESCRIPTION
## 🎫 관련 이슈 (Issue)
Closes #36

## 🛠️ 작업 내용 (Changes)
- [x] GitHub OAuth 로그인 성공 및 로그아웃 이후 프론트 앱 URL로 복귀하는 핸들러를 추가했습니다.
- [x] 프론트 개발 서버 origin에 대해 credential 기반 API 호출이 가능하도록 보안 CORS 설정을 추가했습니다.
- [x] 관련 설정값, README 문서, 리다이렉트/CORS 테스트를 추가하고 보안 회귀 테스트를 통과했습니다.

## 📸 스크린샷 (Optional)
해당 없음

## 🤖 자가 점검 (Self Checklist)
- [x] 코딩 컨벤션(Java Code Style)을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 로컬 환경에서 테스트 코드를 실행하고 통과했나요?
- [x] 새로운 기능에 대한 테스트 코드를 작성했나요?

## 💬 리뷰 포인트 (Review Point)

- 프론트 개발 환경 기본값을 `http://localhost:5173`으로 고정했는데 팀의 로컬 개발 흐름과 맞는지 확인 부탁드립니다.
- 현재 CORS 허용 범위는 `/api/**`, `/logout`, `/oauth2/**`만 열어 두었으니 실제 프론트 통신 범위와 맞는지 봐주시면 됩니다.
- 도메인 API 추가 없이 기존 OAuth 세션 구조를 유지한 채 프론트 복귀만 보강한 방향이 적절한지 확인 부탁드립니다.
